### PR TITLE
Connection string logic and authentication

### DIFF
--- a/src/Bindings/RabbitMQAsyncCollector.cs
+++ b/src/Bindings/RabbitMQAsyncCollector.cs
@@ -25,12 +25,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 throw new ArgumentNullException("context.service");
             }
 
-            _batch = _context.Service.GetBatch();
+            _batch = _context.Service.Batch;
         }
 
         public Task AddAsync(byte[] message, CancellationToken cancellationToken = default)
         {
-            _batch.Add(exchange: _context.ResolvedAttribute.Exchange, routingKey: _context.ResolvedAttribute.QueueName, mandatory: false, properties: _context.ResolvedAttribute.Properties, body: message);
+            _batch.Add(exchange: "", routingKey: _context.ResolvedAttribute.QueueName, mandatory: false, properties: null, body: message);
             _logger.LogDebug($"Adding message to batch for publishing...");
 
             return Task.CompletedTask;
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
         public async Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            await this.PublishAsync();
+            await PublishAsync();
         }
 
         internal Task PublishAsync()

--- a/src/Bindings/RabbitMQAsyncCollector.cs
+++ b/src/Bindings/RabbitMQAsyncCollector.cs
@@ -25,12 +25,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 throw new ArgumentNullException("context.service");
             }
 
-            _batch = _context.Service.Batch;
+            _batch = _context.Service.BasicPublishBatch;
         }
 
         public Task AddAsync(byte[] message, CancellationToken cancellationToken = default)
         {
-            _batch.Add(exchange: "", routingKey: _context.ResolvedAttribute.QueueName, mandatory: false, properties: null, body: message);
+            _batch.Add(exchange: string.Empty, routingKey: _context.ResolvedAttribute.QueueName, mandatory: false, properties: null, body: message);
             _logger.LogDebug($"Adding message to batch for publishing...");
 
             return Task.CompletedTask;

--- a/src/Config/DefaultRabbitMQServiceFactory.cs
+++ b/src/Config/DefaultRabbitMQServiceFactory.cs
@@ -5,9 +5,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     internal class DefaultRabbitMQServiceFactory : IRabbitMQServiceFactory
     {
-        public IRabbitMQService CreateService(string hostName, string queueName)
+        public IRabbitMQService CreateService(string hostName, string queueName, string userName, string password, int port)
         {
-            return new RabbitMQService(hostName, queueName);
+            return new RabbitMQService(hostName, queueName, userName, password, port);
         }
     }
 }

--- a/src/Config/DefaultRabbitMQServiceFactory.cs
+++ b/src/Config/DefaultRabbitMQServiceFactory.cs
@@ -5,9 +5,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     internal class DefaultRabbitMQServiceFactory : IRabbitMQServiceFactory
     {
-        public IRabbitMQService CreateService(string hostName, string queueName, string userName, string password, int port)
+        //public IRabbitMQService CreateService(string connectionString, string queueName)
+        //{
+        //    return new RabbitMQService(connectionString, queueName);
+        //}
+
+        public IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port)
         {
-            return new RabbitMQService(hostName, queueName, userName, password, port);
+            return new RabbitMQService(connectionString, hostName, queueName, userName, password, port);
         }
     }
 }

--- a/src/Config/IRabbitMQServiceFactory.cs
+++ b/src/Config/IRabbitMQServiceFactory.cs
@@ -5,6 +5,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     public interface IRabbitMQServiceFactory
     {
-        IRabbitMQService CreateService(string hostName, string queueName, string userName, string password, int port);
+        IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port);
     }
 }

--- a/src/Config/IRabbitMQServiceFactory.cs
+++ b/src/Config/IRabbitMQServiceFactory.cs
@@ -5,6 +5,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     public interface IRabbitMQServiceFactory
     {
-        IRabbitMQService CreateService(string hostName, string queueName);
+        IRabbitMQService CreateService(string hostName, string queueName, string userName, string password, int port);
     }
 }

--- a/src/Config/RabbitMQExtensionConfigProvider.cs
+++ b/src/Config/RabbitMQExtensionConfigProvider.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         public void ValidateBinding(RabbitMQAttribute attribute, Type type)
         {
             string connectionString = Utility.FirstOrDefault(attribute.ConnectionStringSetting, _options.Value.ConnectionString);
-            string hostName = Utility.FirstOrDefault(attribute.HostName, _options.Value.HostName) ?? Constants.Localhost;
+            string hostName = Utility.FirstOrDefault(attribute.HostName, _options.Value.HostName) ?? Constants.LocalHost;
             _logger.LogInformation("Setting hostName to localhost since it was not specified");
             string queueName = Utility.FirstOrDefault(attribute.QueueName, _options.Value.QueueName) ?? throw new InvalidOperationException("RabbitMQ queue name is missing");
 

--- a/src/Config/RabbitMQExtensionConfigProvider.cs
+++ b/src/Config/RabbitMQExtensionConfigProvider.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             string hostName = Utility.FirstOrDefault(attribute.HostName, _options.Value.HostName);
             string queueName = Utility.FirstOrDefault(attribute.QueueName, _options.Value.QueueName) ?? throw new InvalidOperationException("RabbitMQ queue name is missing");
 
-            if (string.IsNullOrEmpty(connectionString) && !hostName.Equals("localhost", StringComparison.InvariantCultureIgnoreCase))
+            if (!string.IsNullOrEmpty(hostName) && string.IsNullOrEmpty(connectionString) && !hostName.Equals("localhost", StringComparison.InvariantCultureIgnoreCase))
             {
                 string userName = Utility.FirstOrDefault(attribute.UserName, _options.Value.UserName) ?? throw new InvalidOperationException("RabbitMQ username is missing");
                 string password = Utility.FirstOrDefault(attribute.Password, _options.Value.Password) ?? throw new InvalidOperationException("RabbitMQ password is missing");

--- a/src/Config/RabbitMQOptions.cs
+++ b/src/Config/RabbitMQOptions.cs
@@ -11,6 +11,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
         public string QueueName { get; set; }
 
+        public string UserName { get; set; }
+
+        public string Password { get; set; }
+
+        public int Port { get; set; }
+
         public string Exchange { get; set; }
 
         public IBasicProperties Properties { get; set; }

--- a/src/Config/RabbitMQOptions.cs
+++ b/src/Config/RabbitMQOptions.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
         public string Password { get; set; }
 
+        public string ConnectionString { get; set; }
+
         public int Port { get; set; }
 
         public string Exchange { get; set; }

--- a/src/Constants.cs
+++ b/src/Constants.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Azure.WebJobs.Extensions
+{
+    internal static class Constants
+    {
+        public const string Localhost = "localhost";
+    }
+}

--- a/src/Constants.cs
+++ b/src/Constants.cs
@@ -6,6 +6,6 @@ namespace Microsoft.Azure.WebJobs.Extensions
 {
     internal static class Constants
     {
-        public const string Localhost = "localhost";
+        public const string LocalHost = "localhost";
     }
 }

--- a/src/RabbitMQAttribute.cs
+++ b/src/RabbitMQAttribute.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Azure.WebJobs
         // Optional
         public int Port { get; set; }
 
+        public string ConnectionStringSetting { get; set; }
+
         [AutoResolve]
         public string Exchange { get; set; }
 

--- a/src/RabbitMQAttribute.cs
+++ b/src/RabbitMQAttribute.cs
@@ -29,20 +29,16 @@ namespace Microsoft.Azure.WebJobs
         [AutoResolve]
         public string QueueName { get; set; }
 
-        [AutoResolve]
+        [AppSetting]
         public string UserName { get; set; }
 
-        [AutoResolve]
+        [AppSetting]
         public string Password { get; set; }
 
         // Optional
         public int Port { get; set; }
 
+        [ConnectionString]
         public string ConnectionStringSetting { get; set; }
-
-        [AutoResolve]
-        public string Exchange { get; set; }
-
-        public IBasicProperties Properties { get; set; }
     }
 }

--- a/src/RabbitMQAttribute.cs
+++ b/src/RabbitMQAttribute.cs
@@ -30,6 +30,15 @@ namespace Microsoft.Azure.WebJobs
         public string QueueName { get; set; }
 
         [AutoResolve]
+        public string UserName { get; set; }
+
+        [AutoResolve]
+        public string Password { get; set; }
+
+        // Optional
+        public int Port { get; set; }
+
+        [AutoResolve]
         public string Exchange { get; set; }
 
         public IBasicProperties Properties { get; set; }

--- a/src/Services/IRabbitMQService.cs
+++ b/src/Services/IRabbitMQService.cs
@@ -9,6 +9,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
     {
         IModel Model { get; }
 
-        IBasicPublishBatch Batch { get; }
+        IBasicPublishBatch BasicPublishBatch { get; }
     }
 }

--- a/src/Services/IRabbitMQService.cs
+++ b/src/Services/IRabbitMQService.cs
@@ -7,8 +7,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     public interface IRabbitMQService
     {
-        IModel GetChannel();
+        IModel Model { get; }
 
-        IBasicPublishBatch GetBatch();
+        IBasicPublishBatch Batch { get; }
     }
 }

--- a/src/Services/RabbitMQService.cs
+++ b/src/Services/RabbitMQService.cs
@@ -18,7 +18,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         private int _port;
 
         public IModel Model => _model;
-        public IBasicPublishBatch Batch => _batch;
+
+        public IBasicPublishBatch BasicPublishBatch => _batch;
 
         public RabbitMQService(string connectionString, string hostName, string queueName, string userName, string password, int port)
         {
@@ -37,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             _batch = _model.CreateBasicPublishBatch();
         }
 
-        public ConnectionFactory CreateConnectionFactory()
+        internal ConnectionFactory CreateConnectionFactory()
         {
             ConnectionFactory connectionFactory = new ConnectionFactory();
 

--- a/src/Services/RabbitMQService.cs
+++ b/src/Services/RabbitMQService.cs
@@ -10,28 +10,45 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
     {
         private IModel _channel;
         private IBasicPublishBatch _batch;
+        private string _connectionString;
         private string _hostName;
         private string _queueName;
         private string _userName;
         private string _password;
         private int _port;
 
-        public RabbitMQService(string hostName, string queueName, string userName, string password, int port)
+        public RabbitMQService(string connectionString, string hostName, string queueName, string userName, string password, int port)
         {
-            _hostName = hostName ?? throw new ArgumentNullException(nameof(hostName));
+            _connectionString = connectionString;
+            _hostName = hostName;
             _queueName = queueName ?? throw new ArgumentNullException(nameof(queueName));
-            _userName = userName ?? "guest";
-            _password = password ?? "guest";
+            _userName = userName;
+            _password = password;
             _port = port;
 
-            ConnectionFactory connectionFactory = new ConnectionFactory()
-            {
-                HostName = _hostName,
-                UserName = _userName,
-                Password = _password,
-            };
+            ConnectionFactory connectionFactory = new ConnectionFactory();
 
-            // Only set port if it's specified by the user
+            // Only set these if specified by user. Otherwise, API will use default parameters.
+            if (!string.IsNullOrEmpty(_connectionString))
+            {
+                connectionFactory.Uri = new Uri(_connectionString);
+            }
+
+            if (!string.IsNullOrEmpty(_hostName))
+            {
+                connectionFactory.HostName = _hostName;
+            }
+
+            if (!string.IsNullOrEmpty(_userName))
+            {
+                connectionFactory.UserName = _userName;
+            }
+
+            if (!string.IsNullOrEmpty(_password))
+            {
+                connectionFactory.Password = _password;
+            }
+
             if (_port != 0)
             {
                 connectionFactory.Port = _port;

--- a/src/Services/RabbitMQService.cs
+++ b/src/Services/RabbitMQService.cs
@@ -12,13 +12,31 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         private IBasicPublishBatch _batch;
         private string _hostName;
         private string _queueName;
+        private string _userName;
+        private string _password;
+        private int _port;
 
-        public RabbitMQService(string hostName, string queueName)
+        public RabbitMQService(string hostName, string queueName, string userName, string password, int port)
         {
             _hostName = hostName ?? throw new ArgumentNullException(nameof(hostName));
             _queueName = queueName ?? throw new ArgumentNullException(nameof(queueName));
+            _userName = userName ?? "guest";
+            _password = password ?? "guest";
+            _port = port;
 
-            ConnectionFactory connectionFactory = new ConnectionFactory() { HostName = _hostName };
+            ConnectionFactory connectionFactory = new ConnectionFactory()
+            {
+                HostName = _hostName,
+                UserName = _userName,
+                Password = _password,
+            };
+
+            // Only set port if it's specified by the user
+            if (_port != 0)
+            {
+                connectionFactory.Port = _port;
+            }
+
             _channel = connectionFactory.CreateConnection().CreateModel();
 
             _channel.QueueDeclare(queue: _queueName, durable: false, exclusive: false, autoDelete: false, arguments: null);

--- a/src/Trigger/RabbitMQListener.cs
+++ b/src/Trigger/RabbitMQListener.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Executors;
@@ -59,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
             _consumer.Received += (model, ea) =>
             {
-                // Acknowledges messages
+                Console.WriteLine(" [x] Received {0}", Encoding.UTF8.GetString(ea.Body));
                 _channel.BasicAck(ea.DeliveryTag, true);
                 if (_batchNumber == 1)
                 {

--- a/src/Trigger/RabbitMQListener.cs
+++ b/src/Trigger/RabbitMQListener.cs
@@ -59,8 +59,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
             _consumer.Received += (model, ea) =>
             {
-                // Requeues unacknowledged messages.
-                _channel.BasicNack(ea.DeliveryTag, true, true);
+                // Acknowledges messages
+                _channel.BasicAck(ea.DeliveryTag, true);
                 if (_batchNumber == 1)
                 {
                     _executor.TryExecuteAsync(new TriggeredFunctionData() { TriggerValue = ea }, cancellationToken);
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 }
             };
 
-            _consumerTag = _channel.BasicConsume(queue: _queueName, autoAck: true, consumer: _consumer);
+            _consumerTag = _channel.BasicConsume(queue: _queueName, autoAck: false, consumer: _consumer);
 
             _started = true;
 

--- a/src/Trigger/RabbitMQListener.cs
+++ b/src/Trigger/RabbitMQListener.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         private readonly IRabbitMQService _service;
 
         private EventingBasicConsumer _consumer;
-        private IModel _channel;
+        private IModel _model;
         private List<BasicDeliverEventArgs> batchedMessages = new List<BasicDeliverEventArgs>();
 
         private string _consumerTag;
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
         public void Cancel()
         {
-            this.StopAsync(CancellationToken.None).Wait();
+            StopAsync(CancellationToken.None).Wait();
         }
 
         public void Dispose()
@@ -54,13 +54,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 throw new InvalidOperationException("The listener has already been started.");
             }
 
-            _channel = _service.GetChannel();
-            _channel.BasicQos(0, _batchNumber, false);
-            _consumer = new EventingBasicConsumer(_channel);
+            _model = _service.Model;
+            _model.BasicQos(0, _batchNumber, false);
+            _consumer = new EventingBasicConsumer(_model);
 
             _consumer.Received += (model, ea) =>
             {
-                _channel.BasicAck(ea.DeliveryTag, true);
+                _model.BasicAck(ea.DeliveryTag, true);
                 if (_batchNumber == 1)
                 {
                     _executor.TryExecuteAsync(new TriggeredFunctionData() { TriggerValue = ea }, cancellationToken);
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 }
             };
 
-            _consumerTag = _channel.BasicConsume(queue: _queueName, autoAck: false, consumer: _consumer);
+            _consumerTag = _model.BasicConsume(queue: _queueName, autoAck: false, consumer: _consumer);
 
             _started = true;
 
@@ -92,8 +92,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 throw new InvalidOperationException("The listener has not yet been started or has already been stopped");
             }
 
-            _channel.BasicCancel(_consumerTag);
-            _channel.Close();
+            _model.BasicCancel(_consumerTag);
+            _model.Close();
             _started = false;
             _disposed = true;
             return Task.CompletedTask;

--- a/src/Trigger/RabbitMQListener.cs
+++ b/src/Trigger/RabbitMQListener.cs
@@ -60,7 +60,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
             _consumer.Received += (model, ea) =>
             {
-                Console.WriteLine(" [x] Received {0}", Encoding.UTF8.GetString(ea.Body));
                 _channel.BasicAck(ea.DeliveryTag, true);
                 if (_batchNumber == 1)
                 {

--- a/src/Trigger/RabbitMQListener.cs
+++ b/src/Trigger/RabbitMQListener.cs
@@ -59,6 +59,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
             _consumer.Received += (model, ea) =>
             {
+                // Requeues unacknowledged messages.
+                _channel.BasicNack(ea.DeliveryTag, true, true);
                 if (_batchNumber == 1)
                 {
                     _executor.TryExecuteAsync(new TriggeredFunctionData() { TriggerValue = ea }, cancellationToken);

--- a/src/Trigger/RabbitMQTriggerAttribute.cs
+++ b/src/Trigger/RabbitMQTriggerAttribute.cs
@@ -11,37 +11,37 @@ namespace Microsoft.Azure.WebJobs
     {
         public RabbitMQTriggerAttribute(string connectionString, string queueName)
         {
-            this.ConnectionStringSetting = connectionString;
-            this.QueueName = queueName;
+            ConnectionStringSetting = connectionString;
+            QueueName = queueName;
         }
 
         public RabbitMQTriggerAttribute(string queueName)
         {
-            this.QueueName = queueName;
+            QueueName = queueName;
         }
 
         public RabbitMQTriggerAttribute(string hostName, string userName, string password, int port, string queueName)
         {
-            this.HostName = hostName;
-            this.UserName = userName;
-            this.Password = password;
-            this.Port = port;
-            this.QueueName = queueName;
-            this.BatchNumber = 1;
+            HostName = hostName;
+            UserName = userName;
+            Password = password;
+            Port = port;
+            QueueName = queueName;
         }
 
+        [ConnectionString]
         public string ConnectionStringSetting { get;  }
 
         public string HostName { get; }
 
         public string QueueName { get; }
 
+        [AppSetting]
         public string UserName { get; }
 
+        [AppSetting]
         public string Password { get; }
 
         public int Port { get; }
-
-        public ushort BatchNumber { get; }
     }
 }

--- a/src/Trigger/RabbitMQTriggerAttribute.cs
+++ b/src/Trigger/RabbitMQTriggerAttribute.cs
@@ -9,9 +9,9 @@ namespace Microsoft.Azure.WebJobs
     [Binding]
     public sealed class RabbitMQTriggerAttribute : Attribute
     {
-        public RabbitMQTriggerAttribute(string connectionString, string queueName)
+        public RabbitMQTriggerAttribute(string connectionStringSetting, string queueName)
         {
-            ConnectionStringSetting = connectionString;
+            ConnectionStringSetting = connectionStringSetting;
             QueueName = queueName;
         }
 
@@ -20,11 +20,11 @@ namespace Microsoft.Azure.WebJobs
             QueueName = queueName;
         }
 
-        public RabbitMQTriggerAttribute(string hostName, string userName, string password, int port, string queueName)
+        public RabbitMQTriggerAttribute(string hostName, string userNameSetting, string passwordSetting, int port, string queueName)
         {
             HostName = hostName;
-            UserName = userName;
-            Password = password;
+            UserNameSetting = userNameSetting;
+            PasswordSetting = passwordSetting;
             Port = port;
             QueueName = queueName;
         }
@@ -37,10 +37,10 @@ namespace Microsoft.Azure.WebJobs
         public string QueueName { get; }
 
         [AppSetting]
-        public string UserName { get; }
+        public string UserNameSetting { get; }
 
         [AppSetting]
-        public string Password { get; }
+        public string PasswordSetting { get; }
 
         public int Port { get; }
     }

--- a/src/Trigger/RabbitMQTriggerAttribute.cs
+++ b/src/Trigger/RabbitMQTriggerAttribute.cs
@@ -9,11 +9,17 @@ namespace Microsoft.Azure.WebJobs
     [Binding]
     public sealed class RabbitMQTriggerAttribute : Attribute
     {
-        public RabbitMQTriggerAttribute(string hostName, string queueName)
+        public RabbitMQTriggerAttribute(string connectionString, string queueName)
         {
-            this.HostName = hostName;
+            this.ConnectionStringSetting = connectionString;
             this.QueueName = queueName;
         }
+
+        //public RabbitMQTriggerAttribute(string hostName, string queueName)
+        //{
+        //    this.HostName = hostName;
+        //    this.QueueName = queueName;
+        //}
 
         public RabbitMQTriggerAttribute(string hostName, string queueName, ushort batchNumber)
         {
@@ -32,15 +38,17 @@ namespace Microsoft.Azure.WebJobs
             this.BatchNumber = 1;
         }
 
-        public RabbitMQTriggerAttribute(string hostName, string queueName, string userName, string password, int port, ushort batchNumber)
+        public RabbitMQTriggerAttribute(string connectionString, string hostName, string queueName, string userName, string password, int port)
         {
+            this.ConnectionStringSetting = connectionString;
             this.HostName = hostName;
             this.QueueName = queueName;
             this.UserName = userName;
             this.Password = password;
             this.Port = port;
-            this.BatchNumber = batchNumber;
         }
+
+        public string ConnectionStringSetting { get;  }
 
         public string HostName { get; }
 

--- a/src/Trigger/RabbitMQTriggerAttribute.cs
+++ b/src/Trigger/RabbitMQTriggerAttribute.cs
@@ -15,37 +15,19 @@ namespace Microsoft.Azure.WebJobs
             this.QueueName = queueName;
         }
 
-        //public RabbitMQTriggerAttribute(string hostName, string queueName)
-        //{
-        //    this.HostName = hostName;
-        //    this.QueueName = queueName;
-        //}
-
-        public RabbitMQTriggerAttribute(string hostName, string queueName, ushort batchNumber)
+        public RabbitMQTriggerAttribute(string queueName)
         {
-            this.HostName = hostName;
             this.QueueName = queueName;
-            this.BatchNumber = batchNumber;
         }
 
-        public RabbitMQTriggerAttribute(string hostName, string queueName, string userName, string password, int port)
+        public RabbitMQTriggerAttribute(string hostName, string userName, string password, int port, string queueName)
         {
             this.HostName = hostName;
-            this.QueueName = queueName;
             this.UserName = userName;
             this.Password = password;
             this.Port = port;
+            this.QueueName = queueName;
             this.BatchNumber = 1;
-        }
-
-        public RabbitMQTriggerAttribute(string connectionString, string hostName, string queueName, string userName, string password, int port)
-        {
-            this.ConnectionStringSetting = connectionString;
-            this.HostName = hostName;
-            this.QueueName = queueName;
-            this.UserName = userName;
-            this.Password = password;
-            this.Port = port;
         }
 
         public string ConnectionStringSetting { get;  }

--- a/src/Trigger/RabbitMQTriggerAttribute.cs
+++ b/src/Trigger/RabbitMQTriggerAttribute.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Azure.WebJobs
         {
             this.HostName = hostName;
             this.QueueName = queueName;
-            this.BatchNumber = 1;
         }
 
         public RabbitMQTriggerAttribute(string hostName, string queueName, ushort batchNumber)
@@ -23,9 +22,35 @@ namespace Microsoft.Azure.WebJobs
             this.BatchNumber = batchNumber;
         }
 
+        public RabbitMQTriggerAttribute(string hostName, string queueName, string userName, string password, int port)
+        {
+            this.HostName = hostName;
+            this.QueueName = queueName;
+            this.UserName = userName;
+            this.Password = password;
+            this.Port = port;
+            this.BatchNumber = 1;
+        }
+
+        public RabbitMQTriggerAttribute(string hostName, string queueName, string userName, string password, int port, ushort batchNumber)
+        {
+            this.HostName = hostName;
+            this.QueueName = queueName;
+            this.UserName = userName;
+            this.Password = password;
+            this.Port = port;
+            this.BatchNumber = batchNumber;
+        }
+
         public string HostName { get; }
 
         public string QueueName { get; }
+
+        public string UserName { get; }
+
+        public string Password { get; }
+
+        public int Port { get; }
 
         public ushort BatchNumber { get; }
     }

--- a/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
+++ b/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
@@ -39,7 +39,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 return Task.FromResult<ITriggerBinding>(null);
             }
 
-            string queueName = Resolve(attribute.QueueName);
+            string connectionString = Resolve(attribute.ConnectionStringSetting);
+
+            string queueName = Resolve(attribute.QueueName) ?? throw new InvalidOperationException("RabbitMQ queue name is missing");
 
             string hostName = Resolve(attribute.HostName);
 
@@ -51,18 +53,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
             ushort batchNumber = attribute.BatchNumber;
 
-            if (string.IsNullOrEmpty(hostName))
-            {
-                throw new InvalidOperationException("RabbitMQ host name is missing");
-            }
-
-            if (string.IsNullOrEmpty(queueName))
-            {
-                throw new InvalidOperationException("RabbitMQ queue name is missing");
-            }
-
-            if ((string.IsNullOrEmpty(userName) && hostName != "localhost") ||
-                (string.IsNullOrEmpty(password) && hostName != "localhost"))
+            if (string.IsNullOrEmpty(connectionString) && ((string.IsNullOrEmpty(userName) && hostName != "localhost") ||
+                (string.IsNullOrEmpty(password) && hostName != "localhost")))
             {
                 throw new InvalidOperationException("RabbitMQ username and password required if not connecting to localhost");
             }
@@ -73,7 +65,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 batchNumber = 1;
             }
 
-            IRabbitMQService service = _provider.GetService(hostName, queueName, userName, password, port);
+            IRabbitMQService service = _provider.GetService(connectionString, hostName, queueName, userName, password, port);
 
             return Task.FromResult<ITriggerBinding>(new RabbitMQTriggerBinding(service, hostName, queueName, batchNumber));
         }

--- a/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
+++ b/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
             ushort batchNumber = attribute.BatchNumber;
 
-            if (string.IsNullOrEmpty(connectionString) && ((string.IsNullOrEmpty(userName) && hostName != "localhost") ||
+            if (string.IsNullOrEmpty(connectionString) && !string.IsNullOrEmpty(hostName) && ((string.IsNullOrEmpty(userName) && hostName != "localhost") ||
                 (string.IsNullOrEmpty(password) && hostName != "localhost")))
             {
                 throw new InvalidOperationException("RabbitMQ username and password required if not connecting to localhost");

--- a/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
+++ b/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
             string queueName = Resolve(attribute.QueueName) ?? throw new InvalidOperationException("RabbitMQ queue name is missing");
 
-            string hostName = Resolve(attribute.HostName);
+            string hostName = Resolve(attribute.HostName) ?? Constants.Localhost;
 
             string userName = Resolve(attribute.UserName);
 
@@ -51,19 +51,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
             int port = attribute.Port;
 
-            ushort batchNumber = attribute.BatchNumber;
-
-            if (string.IsNullOrEmpty(connectionString) && !string.IsNullOrEmpty(hostName) && ((string.IsNullOrEmpty(userName) && hostName != "localhost") ||
-                (string.IsNullOrEmpty(password) && hostName != "localhost")))
+            if (string.IsNullOrEmpty(connectionString) && !Utility.ValidateUserNamePassword(userName, password, hostName))
             {
                 throw new InvalidOperationException("RabbitMQ username and password required if not connecting to localhost");
             }
 
             // If there's no specified batch number, default to 1
-            if (batchNumber == 0)
-            {
-                batchNumber = 1;
-            }
+            ushort batchNumber = 1;
 
             IRabbitMQService service = _provider.GetService(connectionString, hostName, queueName, userName, password, port);
 

--- a/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
+++ b/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
@@ -43,11 +43,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
             string queueName = Resolve(attribute.QueueName) ?? throw new InvalidOperationException("RabbitMQ queue name is missing");
 
-            string hostName = Resolve(attribute.HostName) ?? Constants.Localhost;
+            string hostName = Resolve(attribute.HostName) ?? Constants.LocalHost;
 
-            string userName = Resolve(attribute.UserName);
+            string userName = Resolve(attribute.UserNameSetting);
 
-            string password = Resolve(attribute.Password);
+            string password = Resolve(attribute.PasswordSetting);
 
             int port = attribute.Port;
 

--- a/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
+++ b/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
@@ -43,9 +43,37 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
             string hostName = Resolve(attribute.HostName);
 
+            string userName = Resolve(attribute.UserName);
+
+            string password = Resolve(attribute.Password);
+
+            int port = attribute.Port;
+
             ushort batchNumber = attribute.BatchNumber;
 
-            IRabbitMQService service = _provider.GetService(hostName, queueName);
+            if (string.IsNullOrEmpty(hostName))
+            {
+                throw new InvalidOperationException("RabbitMQ host name is missing");
+            }
+
+            if (string.IsNullOrEmpty(queueName))
+            {
+                throw new InvalidOperationException("RabbitMQ queue name is missing");
+            }
+
+            if ((string.IsNullOrEmpty(userName) && hostName != "localhost") ||
+                (string.IsNullOrEmpty(password) && hostName != "localhost"))
+            {
+                throw new InvalidOperationException("RabbitMQ username and password required if not connecting to localhost");
+            }
+
+            // If there's no specified batch number, default to 1
+            if (batchNumber == 0)
+            {
+                batchNumber = 1;
+            }
+
+            IRabbitMQService service = _provider.GetService(hostName, queueName, userName, password, port);
 
             return Task.FromResult<ITriggerBinding>(new RabbitMQTriggerBinding(service, hostName, queueName, batchNumber));
         }

--- a/src/Trigger/RabbitMQTriggerParameterDescriptor.cs
+++ b/src/Trigger/RabbitMQTriggerParameterDescriptor.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
         public override string GetTriggerReason(IDictionary<string, string> arguments)
         {
-            return string.Format("RabbitMQ message detected from queue: {0} at {1}", this.QueueName, DateTime.Now);
+            return string.Format("RabbitMQ message detected from queue: {0} at {1}", QueueName, DateTime.Now);
         }
     }
 }

--- a/src/Utility.cs
+++ b/src/Utility.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions
@@ -10,6 +11,29 @@ namespace Microsoft.Azure.WebJobs.Extensions
         internal static string FirstOrDefault(params string[] values)
         {
             return values.FirstOrDefault(v => !string.IsNullOrEmpty(v));
+        }
+
+        internal static int FirstOrDefault(params int[] values)
+        {
+            return values.FirstOrDefault(v =>
+            {
+                if (v != 0)
+                {
+                    return true;
+                }
+
+                return false;
+            });
+        }
+
+        internal static bool ValidateUserNamePassword(string userName, string password, string hostName)
+        {
+            if (!hostName.Equals("localhost", StringComparison.InvariantCultureIgnoreCase) && (string.IsNullOrEmpty(userName) || string.IsNullOrEmpty(password)))
+            {
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/src/Utility.cs
+++ b/src/Utility.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.WebJobs.Extensions
 
         internal static bool ValidateUserNamePassword(string userName, string password, string hostName)
         {
-            if (!hostName.Equals("localhost", StringComparison.InvariantCultureIgnoreCase) && (string.IsNullOrEmpty(userName) || string.IsNullOrEmpty(password)))
+            if (!hostName.Equals(Constants.LocalHost, StringComparison.InvariantCultureIgnoreCase) && (string.IsNullOrEmpty(userName) || string.IsNullOrEmpty(password)))
             {
                 return false;
             }

--- a/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
@@ -74,7 +74,7 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
             logger.LogInformation($"RabbitMQ output binding message: {JsonConvert.SerializeObject(outputMessage)}");
         }
 
-        // Trigger samples
+        //// Trigger samples
         public static void RabbitMQTrigger_String(
              [RabbitMQTrigger("amqp://guest:guest@localhost:5672/", "queue")] string message,
              string consumerTag,
@@ -85,21 +85,21 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
         }
 
         public static void RabbitMQTrigger_BasicDeliverEventArgs(
-            [RabbitMQTrigger("localhost", "queue", 1)] BasicDeliverEventArgs args,
+            [RabbitMQTrigger("queue")] BasicDeliverEventArgs args,
             ILogger logger)
         {
             logger.LogInformation($"RabbitMQ queue trigger function processed message: {Encoding.UTF8.GetString(args.Body)}");
         }
 
         public static void RabbitMQTrigger_JsonToPOCO(
-            [RabbitMQTrigger("localhost", "queue", 1)] TestClass pocObj,
+            [RabbitMQTrigger("queue")] TestClass pocObj,
             ILogger logger)
         {
             logger.LogInformation($"RabbitMQ queue trigger function processed message: {pocObj}");
         }
 
         public static void RabbitMQTrigger_RabbitMQOutput(
-            [RabbitMQTrigger("localhost", "queue", 1)] string inputMessage,
+            [RabbitMQTrigger("queue")] string inputMessage,
             [RabbitMQ(
                 HostName = "localhost",
                 QueueName = "hello")] out string outputMessage,

--- a/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+﻿//// Copyright (c) .NET Foundation. All rights reserved.
+//// Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Text;
 using System.Threading.Tasks;

--- a/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
@@ -26,9 +26,7 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
 
         public static void TimerTrigger_PocoOutput(
              [TimerTrigger("00:01")] TimerInfo timer,
-             [RabbitMQ(
-                  HostName = "localhost",
-                  QueueName = "queue")] out TestClass outputMessage,
+             [RabbitMQ(HostName = "localhost", QueueName = "queue")] out TestClass outputMessage,
              ILogger logger)
         {
             outputMessage = new TestClass(1, 1);
@@ -45,9 +43,7 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
         // So you can add items to the queue while the sample is running, and the trigger will be called until the queue is empty.
         public static async Task ProcessMessage_RabbitMQAsyncCollector(
             [QueueTrigger(@"samples-rabbitmq-messages")] string message,
-            [RabbitMQ(
-                HostName = "localhost",
-                QueueName = "queue")] IAsyncCollector<byte[]> messages,
+            [RabbitMQ(QueueName = "queue")] IAsyncCollector<byte[]> messages,
             ILogger logger)
         {
             logger.LogInformation($"Received queue trigger");
@@ -65,16 +61,14 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
         // So you can add items to the queue while the sample is running, and the trigger will be called until the queue is empty.
         public static void QueueTrigger_RabbitMQOutput(
             [QueueTrigger(@"samples-rabbitmq-messages")] TestClass message,
-            [RabbitMQ(
-                HostName = "localhost",
-                QueueName = "queue")] out TestClass outputMessage,
+            [RabbitMQ(QueueName = "queue")] out TestClass outputMessage,
             ILogger logger)
         {
             outputMessage = message;
             logger.LogInformation($"RabbitMQ output binding message: {JsonConvert.SerializeObject(outputMessage)}");
         }
 
-        //// Trigger samples
+        // Trigger samples
         public static void RabbitMQTrigger_String(
              [RabbitMQTrigger("amqp://guest:guest@localhost:5672/", "queue")] string message,
              string consumerTag,

--- a/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
@@ -13,11 +13,9 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
     public static class RabbitMQSamples
     {
         // Output samples
-        public static void TimerTrigger_StringOutput(
+        public static void TimerTrigger_ConnectionString_StringOutput(
             [TimerTrigger("00:01")] TimerInfo timer,
-            [RabbitMQ(
-                ConnectionStringSetting = "amqp://guest:guest@localhost:5672/",
-                QueueName = "queue")] out string outputMessage,
+            [RabbitMQ(QueueName = "queue")] out string outputMessage,
             ILogger logger)
         {
             outputMessage = "new";
@@ -69,8 +67,9 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
         }
 
         // Trigger samples
+        // Defaults to localhost if HostName is not specified
         public static void RabbitMQTrigger_String(
-             [RabbitMQTrigger("amqp://guest:guest@localhost:5672/", "queue")] string message,
+             [RabbitMQTrigger("queue")] string message,
              string consumerTag,
              ILogger logger)
         {
@@ -105,13 +104,13 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
 
         public class TestClass
         {
-            private readonly int x;
-            private readonly int y;
+            private readonly int _x;
+            private readonly int _y;
 
             public TestClass(int x, int y)
             {
-                this.x = x;
-                this.y = y;
+                _x = x;
+                _y = y;
             }
         }
     }

--- a/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
@@ -1,5 +1,5 @@
-﻿//// Copyright (c) .NET Foundation. All rights reserved.
-//// Licensed under the MIT License. See License.txt in the project root for license information.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Text;
 using System.Threading.Tasks;
@@ -16,7 +16,7 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
         public static void TimerTrigger_StringOutput(
             [TimerTrigger("00:01")] TimerInfo timer,
             [RabbitMQ(
-                HostName = "localhost",
+                ConnectionStringSetting = "amqp://guest:guest@localhost:5672/",
                 QueueName = "queue")] out string outputMessage,
             ILogger logger)
         {
@@ -76,7 +76,7 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
 
         // Trigger samples
         public static void RabbitMQTrigger_String(
-             [RabbitMQTrigger("localhost", "queue")] string message,
+             [RabbitMQTrigger("amqp://guest:guest@localhost:5672/", "queue")] string message,
              string consumerTag,
              ILogger logger)
         {
@@ -85,21 +85,21 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
         }
 
         public static void RabbitMQTrigger_BasicDeliverEventArgs(
-            [RabbitMQTrigger("localhost", "queue")] BasicDeliverEventArgs args,
+            [RabbitMQTrigger("localhost", "queue", 1)] BasicDeliverEventArgs args,
             ILogger logger)
         {
             logger.LogInformation($"RabbitMQ queue trigger function processed message: {Encoding.UTF8.GetString(args.Body)}");
         }
 
         public static void RabbitMQTrigger_JsonToPOCO(
-            [RabbitMQTrigger("localhost", "queue")] TestClass pocObj,
+            [RabbitMQTrigger("localhost", "queue", 1)] TestClass pocObj,
             ILogger logger)
         {
             logger.LogInformation($"RabbitMQ queue trigger function processed message: {pocObj}");
         }
 
         public static void RabbitMQTrigger_RabbitMQOutput(
-            [RabbitMQTrigger("localhost", "queue")] string inputMessage,
+            [RabbitMQTrigger("localhost", "queue", 1)] string inputMessage,
             [RabbitMQ(
                 HostName = "localhost",
                 QueueName = "hello")] out string outputMessage,

--- a/test/WebJobs.Extensions.RabbitMQ.Samples/SamplesTypeLocator.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Samples/SamplesTypeLocator.cs
@@ -9,16 +9,16 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
 {
     public class SamplesTypeLocator : ITypeLocator
     {
-        private Type[] types;
+        private Type[] _types;
 
         public SamplesTypeLocator(params Type[] types)
         {
-            this.types = types;
+            _types = types;
         }
 
         public IReadOnlyList<Type> GetTypes()
         {
-            return this.types;
+            return _types;
         }
     }
 }

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/BasicDeliverEventArgsToPocoConverterTests.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/BasicDeliverEventArgsToPocoConverterTests.cs
@@ -50,8 +50,8 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
 
             public TestClass(int x, int y)
             {
-                this.x = x;
-                this.y = y;
+                x = x;
+                y = y;
             }
         }
     }

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/PocoToBytesConverterTests.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/PocoToBytesConverterTests.cs
@@ -34,8 +34,8 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
 
             public TestClass(int x, int y)
             {
-                this.x = x;
-                this.y = y;
+                x = x;
+                y = y;
             }
         }
     }

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQAsyncCollectorTests.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQAsyncCollectorTests.cs
@@ -21,7 +21,7 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
         {
             var mockRabbitMQService = new Mock<IRabbitMQService>(MockBehavior.Strict);
             var mockBatch = new Mock<IBasicPublishBatch>();
-            mockRabbitMQService.Setup(m => m.Batch).Returns(mockBatch.Object);
+            mockRabbitMQService.Setup(m => m.BasicPublishBatch).Returns(mockBatch.Object);
 
             var attribute = new RabbitMQAttribute
             {

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQAsyncCollectorTests.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQAsyncCollectorTests.cs
@@ -21,7 +21,7 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
         {
             var mockRabbitMQService = new Mock<IRabbitMQService>(MockBehavior.Strict);
             var mockBatch = new Mock<IBasicPublishBatch>();
-            mockRabbitMQService.Setup(m => m.GetBatch()).Returns(mockBatch.Object);
+            mockRabbitMQService.Setup(m => m.Batch).Returns(mockBatch.Object);
 
             var attribute = new RabbitMQAttribute
             {

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQConfigProviderTests.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQConfigProviderTests.cs
@@ -16,7 +16,7 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
         [Fact]
         public void Creates_Context_Correctly()
         {
-            var options = new RabbitMQOptions { HostName = "localhost", QueueName = "hello" };
+            var options = new RabbitMQOptions { HostName = Constants.LocalHost, QueueName = "hello" };
             var loggerFactory = new LoggerFactory();
             var mockServiceFactory = new Mock<IRabbitMQServiceFactory>();
             var mockNameResolver = new Mock<INameResolver>();
@@ -41,9 +41,9 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
         }
 
         [Theory]
-        [InlineData("localhost", "queue", null, null)]
-        [InlineData(null, "hello", "localhost", null)]
-        [InlineData(null, null, "localhost", "name")]
+        [InlineData(Constants.LocalHost, "queue", null, null)]
+        [InlineData(null, "hello", Constants.LocalHost, null)]
+        [InlineData(null, null, Constants.LocalHost, "name")]
         public void Handles_Null_Attributes_And_Options(string attrHostname, string attrQueueName, string optHostname, string optQueueName)
         {
             RabbitMQAttribute attr = new RabbitMQAttribute

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQServiceTests.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQServiceTests.cs
@@ -9,37 +9,31 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
     public class RabbitMQServiceTests
     {
         [Theory]
-        [InlineData(null, "localhost", "queue", "guest", "guest", 5672)]
-        [InlineData("amqp://user:PASSWORD@52.175.195.81:5672", null, "queue", null, null, null)]
-        [InlineData(null, "localhost", "queue", null, null, 0)] // Should fill in "guest", "guest", 5672
-        public void Handles_Connection_Attributes_And_Options(string connectionString, string hostName, string queueName, string userName, string password, int port)
+        [InlineData("", "localhost", "queue", "guest", "guest", 5672, "", "localhost", "guest", "guest", 5672)]
+        [InlineData("amqp://user:PASSWORD@52.175.195.81:5672", null, "queue", null, null, null, "amqp://user:PASSWORD@52.175.195.81:5672", "52.175.195.81", "user", "PASSWORD", 5672)]
+        [InlineData("", "localhost", "queue", null, null, 0, "", "localhost", "guest", "guest", -1)] // Should fill in "guest", "guest", 5672
+        public void Handles_Connection_Attributes_And_Options(string connectionString, string hostName, string queueName, string userName, string password, int port,
+            string expectedConnectionString, string expectedHostName, string expectedUserName, string expectedPassword, int expectedPort)
         {
             RabbitMQService service = new RabbitMQService(connectionString, hostName, queueName, userName, password, port);
 
             ConnectionFactory factory = service.CreateConnectionFactory();
-            if (connectionString == null && userName == "guest")
+
+            if (String.IsNullOrEmpty(connectionString))
             {
                 Assert.Null(factory.Uri);
-                Assert.Equal("localhost", factory.HostName);
-                Assert.Equal("guest", factory.UserName);
-                Assert.Equal("guest", factory.Password);
-                Assert.Equal(5672, factory.Port);
+                Assert.Equal(expectedHostName, factory.HostName);
+                Assert.Equal(expectedUserName, factory.UserName);
+                Assert.Equal(expectedPassword, factory.Password);
+                Assert.Equal(expectedPort, factory.Port);
             }
-            else if (connectionString != null)
+            else
             {
-                Assert.Equal(new Uri("amqp://user:PASSWORD@52.175.195.81:5672"), factory.Uri);
-                Assert.Equal("52.175.195.81", factory.HostName);
-                Assert.Equal("user", factory.UserName);
-                Assert.Equal("PASSWORD", factory.Password);
-                Assert.Equal(5672, factory.Port);
-            }
-            else if (port == 0)
-            {
-                Assert.Null(factory.Uri);
-                Assert.Equal("localhost", factory.HostName);
-                Assert.Equal("guest", factory.UserName);
-                Assert.Equal("guest", factory.Password);
-                Assert.Equal(-1, factory.Port);
+                Assert.Equal(new Uri(expectedConnectionString), factory.Uri);
+                Assert.Equal(expectedHostName, factory.HostName);
+                Assert.Equal(expectedUserName, factory.UserName);
+                Assert.Equal(expectedPassword, factory.Password);
+                Assert.Equal(expectedPort, factory.Port);
             }
         }
     }

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQServiceTests.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQServiceTests.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Microsoft.Azure.WebJobs.Extensions.RabbitMQ;
+using Moq;
+using RabbitMQ.Client;
+using Xunit;
+
+namespace WebJobs.Extensions.RabbitMQ.Tests
+{
+    public class RabbitMQServiceTests
+    {
+        [Theory]
+        [InlineData(null, "localhost", "queue", "guest", "guest", 5672)]
+        [InlineData("amqp://user:PASSWORD@52.175.195.81:5672", null, "queue", null, null, null)]
+        [InlineData(null, "localhost", "queue", null, null, 0)] // Should fill in "guest", "guest", 5672
+        public void Handles_Connection_Attributes_And_Options(string connectionString, string hostName, string queueName, string userName, string password, int port)
+        {
+            RabbitMQService service = new RabbitMQService(connectionString, hostName, queueName, userName, password, port);
+
+            ConnectionFactory factory = service.CreateConnectionFactory();
+            if (connectionString == null && userName == "guest")
+            {
+                Assert.Null(factory.Uri);
+                Assert.Equal("localhost", factory.HostName);
+                Assert.Equal("guest", factory.UserName);
+                Assert.Equal("guest", factory.Password);
+                Assert.Equal(5672, factory.Port);
+            }
+            else if (connectionString != null)
+            {
+                Assert.Equal(new Uri("amqp://user:PASSWORD@52.175.195.81:5672"), factory.Uri);
+                Assert.Equal("52.175.195.81", factory.HostName);
+                Assert.Equal("user", factory.UserName);
+                Assert.Equal("PASSWORD", factory.Password);
+                Assert.Equal(5672, factory.Port);
+            }
+            else if (port == 0)
+            {
+                Assert.Null(factory.Uri);
+                Assert.Equal("localhost", factory.HostName);
+                Assert.Equal("guest", factory.UserName);
+                Assert.Equal("guest", factory.Password);
+                Assert.Equal(-1, factory.Port);
+            }
+        }
+    }
+}
+

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/UtilityTests.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/UtilityTests.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Azure.WebJobs.Extensions;
+using Xunit;
+
+namespace WebJobs.Extensions.RabbitMQ.Tests
+{
+    public class UtilityTests
+    {
+        [Fact]
+        public void InvalidCredentials_ReturnsFalse()
+        {
+            string host = "52.175.195.81";
+            string userName = "";
+            string password = "";
+
+            Assert.False(Utility.ValidateUserNamePassword(userName, password, host));
+        }
+
+        [Fact]
+        public void ValidCredentials_ReturnsTrue()
+        {
+            string host = "52.175.195.81";
+            string userName = "user";
+            string password = "PASSWORD";
+
+            Assert.True(Utility.ValidateUserNamePassword(userName, password, host));
+        }
+    }
+}

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/UtilityTests.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/UtilityTests.cs
@@ -8,24 +8,19 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
 {
     public class UtilityTests
     {
-        [Fact]
-        public void InvalidCredentials_ReturnsFalse()
+        [Theory]
+        [InlineData("52.175.195.81", "", "")]
+        [InlineData("52.175.195.81", "user", "PASSWORD")]
+        public void ValidateCredentials(string hostName, string userName, string password)
         {
-            string host = "52.175.195.81";
-            string userName = "";
-            string password = "";
-
-            Assert.False(Utility.ValidateUserNamePassword(userName, password, host));
-        }
-
-        [Fact]
-        public void ValidCredentials_ReturnsTrue()
-        {
-            string host = "52.175.195.81";
-            string userName = "user";
-            string password = "PASSWORD";
-
-            Assert.True(Utility.ValidateUserNamePassword(userName, password, host));
+            if (String.IsNullOrEmpty(userName))
+            {
+                Assert.False(Utility.ValidateUserNamePassword(userName, password, hostName));
+            } 
+            else
+            {
+                Assert.True(Utility.ValidateUserNamePassword(userName, password, hostName));
+            }
         }
     }
 }


### PR DESCRIPTION
Adding logic for configuring output/trigger with a connection string instead of individual host/user/pw/port parameters. Needs some cleanup

For the output implementation, I decided to include all params PLUS the connection string as optional attributes and then let the RabbitMQ API handle any missing fields. I think this makes the most sense as I would have to do a lot of unnecessary error checking otherwise.

How to design the trigger is a little trickier. The RabbitMQ API has defaults for any missing fields so the user should essentially be able to pass in whatever parameters they wish to, but this makes the trigger code a lot more complicated if we want to account for all of these combinations. Because I have to create trigger objects, I thought about writing a bunch of overloaded constructors to handle different combinations of filled in/missing fields. I've written a few overloaded constructors in this PR but I wanted some feedback on whether or not this is the best way to handle this issue because then I'd have to create like 10+ constructors. 

Also: closing https://github.com/Azure/azure-functions-rabbitmq-extension/pull/27 to combine authentication and connection string logic into one PR

Edit: Adding requeuing logic here as well since it's not a lot of code. Will need to verify whether this is exactly what we want to do but according to [documentation](https://www.rabbitmq.com/confirms.html#consumer-nacks-requeue) this seems to be the solution we want?

Edit 2: The NACK logic seems to requeue over and over even when something hasn't gone wrong. Some say the default behavior is that the message won't leave the queue if there's an error. I need to confirm this but if it's true we don't need to add any other logic for resending
