### PR TITLE
Add dead letter exchange logic

### DIFF
--- a/src/Config/DefaultRabbitMQServiceFactory.cs
+++ b/src/Config/DefaultRabbitMQServiceFactory.cs
@@ -5,9 +5,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     internal class DefaultRabbitMQServiceFactory : IRabbitMQServiceFactory
     {
-        public IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port)
+        public IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port, string deadLetterExchangeName)
         {
-            return new RabbitMQService(connectionString, hostName, queueName, userName, password, port);
+            return new RabbitMQService(connectionString, hostName, queueName, userName, password, port, deadLetterExchangeName);
         }
     }
 }

--- a/src/Config/IRabbitMQServiceFactory.cs
+++ b/src/Config/IRabbitMQServiceFactory.cs
@@ -5,6 +5,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     public interface IRabbitMQServiceFactory
     {
-        IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port);
+        IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port, string deadLetterExchangeName);
     }
 }

--- a/src/Config/RabbitMQExtensionConfigProvider.cs
+++ b/src/Config/RabbitMQExtensionConfigProvider.cs
@@ -90,6 +90,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             string userName = Utility.FirstOrDefault(attribute.UserName, _options.Value.UserName);
             string password = Utility.FirstOrDefault(attribute.Password, _options.Value.Password);
             int port = Utility.FirstOrDefault(attribute.Port, _options.Value.Port);
+            string deadLetterExchangeName = Utility.FirstOrDefault(attribute.DeadLetterExchangeName, _options.Value.DeadLetterExchangeName);
 
 
             RabbitMQAttribute resolvedAttribute;
@@ -103,9 +104,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 UserName = userName,
                 Password = password,
                 Port = port,
+                DeadLetterExchangeName = deadLetterExchangeName,
             };
 
-            service = GetService(connectionString, hostName, queueName, userName, password, port);
+            service = GetService(connectionString, hostName, queueName, userName, password, port, deadLetterExchangeName);
 
             return new RabbitMQContext
             {
@@ -114,9 +116,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             };
         }
 
-        internal IRabbitMQService GetService(string connectionString, string hostName, string queueName, string userName, string password, int port)
+        internal IRabbitMQService GetService(string connectionString, string hostName, string queueName, string userName, string password, int port, string deadLetterExchangeName)
         {
-            return _rabbitMQServiceFactory.CreateService(connectionString, hostName, queueName, userName, password, port);
+            return _rabbitMQServiceFactory.CreateService(connectionString, hostName, queueName, userName, password, port, deadLetterExchangeName);
         }
     }
 }

--- a/src/Config/RabbitMQOptions.cs
+++ b/src/Config/RabbitMQOptions.cs
@@ -19,5 +19,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         public string ConnectionString { get; set; }
 
         public int Port { get; set; }
+
+        public string DeadLetterExchangeName { get; set; }
     }
 }

--- a/src/Constants.cs
+++ b/src/Constants.cs
@@ -5,5 +5,6 @@
         public const string LocalHost = "localhost";
         public const string RabbitMQ = "RabbitMQ";
         public const string RequeueCount = "requeueCount";
+        public const string DeadLetterExchangeKey = "x-dead-letter-exchange";
     }
 }

--- a/src/Constants.cs
+++ b/src/Constants.cs
@@ -6,5 +6,6 @@
         public const string RabbitMQ = "RabbitMQ";
         public const string RequeueCount = "requeueCount";
         public const string DeadLetterExchangeKey = "x-dead-letter-exchange";
+        public const string DefaultDLXSetting = "direct";
     }
 }

--- a/src/Constants.cs
+++ b/src/Constants.cs
@@ -7,5 +7,7 @@
         public const string RequeueCount = "requeueCount";
         public const string DeadLetterExchangeKey = "x-dead-letter-exchange";
         public const string DefaultDLXSetting = "direct";
+        public const string DeadLetterRoutingKey = "x-dead-letter-routing-key";
+        public const string DeadLetterRoutingKeyValue = "poison-queue";
     }
 }

--- a/src/RabbitMQAttribute.cs
+++ b/src/RabbitMQAttribute.cs
@@ -40,5 +40,7 @@ namespace Microsoft.Azure.WebJobs
 
         [ConnectionString]
         public string ConnectionStringSetting { get; set; }
+
+        public string DeadLetterExchangeName { get; set; }
     }
 }

--- a/src/RabbitMQAttribute.cs
+++ b/src/RabbitMQAttribute.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Azure.WebJobs
         [ConnectionString]
         public string ConnectionStringSetting { get; set; }
 
+        [AutoResolve]
         public string DeadLetterExchangeName { get; set; }
     }
 }

--- a/src/Services/RabbitMQService.cs
+++ b/src/Services/RabbitMQService.cs
@@ -38,15 +38,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             IModel model = connectionFactory.CreateConnection().CreateModel();
             _model = new RabbitMQModel(model);
 
-            // Create dead letter queue
-            string deadLetterQueueName = string.Format("{0}-poison", _queueName);
-            _model.QueueDeclare(queue: deadLetterQueueName, durable: false, exclusive: false, autoDelete: false, arguments: null);
-            _model.ExchangeDeclare(_deadLetterExchangeName, Constants.DefaultDLXSetting);
-            _model.QueueBind(deadLetterQueueName, _deadLetterExchangeName, Constants.DeadLetterRoutingKeyValue, null);
-
             Dictionary<string, object> args = new Dictionary<string, object>();
-            args[Constants.DeadLetterExchangeKey] = _deadLetterExchangeName;
-            args[Constants.DeadLetterRoutingKey] = Constants.DeadLetterRoutingKeyValue;
+
+            // Create dead letter queue
+            if (_deadLetterExchangeName != "")
+            {
+                string deadLetterQueueName = string.Format("{0}-poison", _queueName);
+                _model.QueueDeclare(queue: deadLetterQueueName, durable: false, exclusive: false, autoDelete: false, arguments: null);
+                _model.ExchangeDeclare(_deadLetterExchangeName, Constants.DefaultDLXSetting);
+                _model.QueueBind(deadLetterQueueName, _deadLetterExchangeName, Constants.DeadLetterRoutingKeyValue, null);
+
+                args[Constants.DeadLetterExchangeKey] = _deadLetterExchangeName;
+                args[Constants.DeadLetterRoutingKey] = Constants.DeadLetterRoutingKeyValue;
+            }
 
             _model.QueueDeclare(queue: _queueName, durable: false, exclusive: false, autoDelete: false, arguments: args);
             _batch = _model.CreateBasicPublishBatch();

--- a/src/Services/RabbitMQService.cs
+++ b/src/Services/RabbitMQService.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             IModel model = connectionFactory.CreateConnection().CreateModel();
             _model = new RabbitMQModel(model);
 
-            _model.ExchangeDeclare(_deadLetterExchangeName, "direct");
+            _model.ExchangeDeclare(_deadLetterExchangeName, Constants.DefaultDLXSetting);
             Dictionary<string, object> args = new Dictionary<string, object>();
             args[Constants.DeadLetterExchangeKey] = _deadLetterExchangeName;
 

--- a/src/Services/RabbitMQService.cs
+++ b/src/Services/RabbitMQService.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             Dictionary<string, object> args = new Dictionary<string, object>();
 
             // Create dead letter queue
-            if (_deadLetterExchangeName != "")
+            if (!string.IsNullOrEmpty(_deadLetterExchangeName))
             {
                 string deadLetterQueueName = string.Format("{0}-poison", _queueName);
                 _model.QueueDeclare(queue: deadLetterQueueName, durable: false, exclusive: false, autoDelete: false, arguments: null);

--- a/src/Trigger/IRabbitMQModel.cs
+++ b/src/Trigger/IRabbitMQModel.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
         void BasicCancel(string consumerTag);
 
-        void ExchangeDeclare(string exchange, string type);
+        void ExchangeDeclare(string exchange, string exchangeType);
 
         void Close();
     }

--- a/src/Trigger/IRabbitMQModel.cs
+++ b/src/Trigger/IRabbitMQModel.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
         QueueDeclareOk QueueDeclare(string queue, bool durable, bool exclusive, bool autoDelete, IDictionary<string, object> arguments);
 
+        void QueueBind(string queue, string exchange, string routingKey, IDictionary<string, object> arguments);
+
         void BasicQos(uint prefetchSize, ushort prefetchCount, bool global);
 
         string BasicConsume(string queue, bool autoAck, IBasicConsumer consumer);

--- a/src/Trigger/IRabbitMQModel.cs
+++ b/src/Trigger/IRabbitMQModel.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
         void BasicCancel(string consumerTag);
 
+        void ExchangeDeclare(string exchange, string type);
+
         void Close();
     }
 }

--- a/src/Trigger/RabbitMQListener.cs
+++ b/src/Trigger/RabbitMQListener.cs
@@ -114,6 +114,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             }
 
             ea.BasicProperties.Headers[Constants.RequeueCount] = 0;
+
             _logger.LogDebug("Republishing message");
             _rabbitMQModel.BasicPublish(exchange: string.Empty, routingKey: ea.RoutingKey, basicProperties: ea.BasicProperties, body: ea.Body);
         }

--- a/src/Trigger/RabbitMQModel.cs
+++ b/src/Trigger/RabbitMQModel.cs
@@ -57,9 +57,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             _model.BasicCancel(consumerTag);
         }
 
-        public void ExchangeDeclare(string exchange, string type)
+        public void ExchangeDeclare(string exchange, string exchangeType)
         {
-            _model.ExchangeDeclare(exchange, type);
+            _model.ExchangeDeclare(exchange, exchangeType);
         }
 
         public void Close()

--- a/src/Trigger/RabbitMQModel.cs
+++ b/src/Trigger/RabbitMQModel.cs
@@ -57,6 +57,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             _model.BasicCancel(consumerTag);
         }
 
+        public void ExchangeDeclare(string exchange, string type)
+        {
+            _model.ExchangeDeclare(exchange, type);
+        }
+
         public void Close()
         {
             _model.Close();

--- a/src/Trigger/RabbitMQModel.cs
+++ b/src/Trigger/RabbitMQModel.cs
@@ -27,6 +27,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             return _model.QueueDeclare(queue, durable, exclusive, autoDelete, arguments);
         }
 
+        public void QueueBind(string queue, string exchange, string routingKey, IDictionary<string, object> args)
+        {
+            _model.QueueBind(queue, exchange, routingKey, args);
+        }
+
         public void BasicQos(uint prefetchSize, ushort prefetchCount, bool global)
         {
             _model.BasicQos(prefetchSize, prefetchCount, global);

--- a/src/Trigger/RabbitMQTriggerAttribute.cs
+++ b/src/Trigger/RabbitMQTriggerAttribute.cs
@@ -9,24 +9,27 @@ namespace Microsoft.Azure.WebJobs
     [Binding]
     public sealed class RabbitMQTriggerAttribute : Attribute
     {
-        public RabbitMQTriggerAttribute(string connectionStringSetting, string queueName)
+        public RabbitMQTriggerAttribute(string connectionStringSetting, string queueName, string deadLetterExchangeName)
         {
             ConnectionStringSetting = connectionStringSetting;
             QueueName = queueName;
+            DeadLetterExchangeName = deadLetterExchangeName;
         }
 
-        public RabbitMQTriggerAttribute(string queueName)
+        public RabbitMQTriggerAttribute(string queueName, string deadLetterExchangeName)
         {
             QueueName = queueName;
+            DeadLetterExchangeName = deadLetterExchangeName;
         }
 
-        public RabbitMQTriggerAttribute(string hostName, string userNameSetting, string passwordSetting, int port, string queueName)
+        public RabbitMQTriggerAttribute(string hostName, string userNameSetting, string passwordSetting, int port, string queueName, string deadLetterExchangeName)
         {
             HostName = hostName;
             UserNameSetting = userNameSetting;
             PasswordSetting = passwordSetting;
             Port = port;
             QueueName = queueName;
+            DeadLetterExchangeName = deadLetterExchangeName;
         }
 
         [ConnectionString]
@@ -43,5 +46,7 @@ namespace Microsoft.Azure.WebJobs
         public string PasswordSetting { get; }
 
         public int Port { get; }
+
+        public string DeadLetterExchangeName { get; }
     }
 }

--- a/src/Trigger/RabbitMQTriggerAttribute.cs
+++ b/src/Trigger/RabbitMQTriggerAttribute.cs
@@ -9,20 +9,21 @@ namespace Microsoft.Azure.WebJobs
     [Binding]
     public sealed class RabbitMQTriggerAttribute : Attribute
     {
-        public RabbitMQTriggerAttribute(string connectionStringSetting, string queueName, string deadLetterExchangeName)
+        public RabbitMQTriggerAttribute(string connectionStringSetting, string queueName, string deadLetterExchangeName = "")
         {
             ConnectionStringSetting = connectionStringSetting;
             QueueName = queueName;
             DeadLetterExchangeName = deadLetterExchangeName;
         }
 
-        public RabbitMQTriggerAttribute(string queueName, string deadLetterExchangeName)
+
+        public RabbitMQTriggerAttribute(string queueName, string deadLetterExchangeName = "")
         {
             QueueName = queueName;
             DeadLetterExchangeName = deadLetterExchangeName;
         }
 
-        public RabbitMQTriggerAttribute(string hostName, string userNameSetting, string passwordSetting, int port, string queueName, string deadLetterExchangeName)
+        public RabbitMQTriggerAttribute(string hostName, string userNameSetting, string passwordSetting, int port, string queueName, string deadLetterExchangeName = "")
         {
             HostName = hostName;
             UserNameSetting = userNameSetting;

--- a/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
+++ b/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
             string password = Resolve(attribute.PasswordSetting);
 
-            string deadLetterExchangeName = Resolve(attribute.DeadLetterExchangeName) ?? throw new InvalidOperationException("Must provide a dead letter exchange name in case of poisoned messages");
+            string deadLetterExchangeName = Resolve(attribute.DeadLetterExchangeName) ?? throw new InvalidOperationException("Dead letter exchange name missing");
 
             int port = attribute.Port;
 

--- a/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
+++ b/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
             string password = Resolve(attribute.PasswordSetting);
 
-            string deadLetterExchangeName = Resolve(attribute.DeadLetterExchangeName) ?? throw new InvalidOperationException("Dead letter exchange name missing");
+            string deadLetterExchangeName = Resolve(attribute.DeadLetterExchangeName) ?? string.Empty;
 
             int port = attribute.Port;
 

--- a/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
+++ b/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
@@ -59,6 +59,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
             string password = Resolve(attribute.PasswordSetting);
 
+            string deadLetterExchangeName = Resolve(attribute.DeadLetterExchangeName) ?? throw new InvalidOperationException("Must provide a dead letter exchange name in case of poisoned messages");
+
             int port = attribute.Port;
 
             if (string.IsNullOrEmpty(connectionString) && !Utility.ValidateUserNamePassword(userName, password, hostName))
@@ -69,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             // If there's no specified batch number, default to 1
             ushort batchNumber = 1;
 
-            IRabbitMQService service = _provider.GetService(connectionString, hostName, queueName, userName, password, port);
+            IRabbitMQService service = _provider.GetService(connectionString, hostName, queueName, userName, password, port, deadLetterExchangeName);
 
             return Task.FromResult<ITriggerBinding>(new RabbitMQTriggerBinding(service, hostName, queueName, batchNumber, _logger));
         }

--- a/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
@@ -106,6 +106,14 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
             logger.LogInformation($"RabbitMQ queue trigger function processed message: {pocObj}");
         }
 
+        public static void RabbitMQTrigger_JsonToPOCO(
+            [RabbitMQTrigger(connectionStringSetting: "rabbitMQ", "new_test_queue-poison", "dlxName")] string res,
+            ILogger logger)
+        {
+            logger.LogInformation($"RabbitMQ queue trigger function processed message: {res}");
+        }
+
+
         public static void RabbitMQTrigger_RabbitMQOutput(
             [RabbitMQTrigger("queue", "dlxName")] string inputMessage,
             [RabbitMQ(

--- a/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
@@ -110,7 +110,7 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
 
         // This sample waits on messages from the poison queue created by the above sample.
         // It should process it correctly since it's configured to be of type string.
-        public static void RabbitMQTrigger_JsonToPOCO_DeadLetter(
+        public static void RabbitMQTrigger_Process_PoisonQueue(
             [RabbitMQTrigger(connectionStringSetting: "rabbitMQ", "new_test_queue-poison")] string res,
             ILogger logger)
         {

--- a/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
@@ -106,8 +106,8 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
             logger.LogInformation($"RabbitMQ queue trigger function processed message: {pocObj}");
         }
 
-        public static void RabbitMQTrigger_JsonToPOCO(
-            [RabbitMQTrigger(connectionStringSetting: "rabbitMQ", "new_test_queue-poison", "dlxName")] string res,
+        public static void RabbitMQTrigger_JsonToPOCO_DeadLetter(
+            [RabbitMQTrigger(connectionStringSetting: "rabbitMQ", "new_test_queue-poison")] string res,
             ILogger logger)
         {
             logger.LogInformation($"RabbitMQ queue trigger function processed message: {res}");

--- a/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
@@ -99,6 +99,8 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
             logger.LogInformation($"RabbitMQ queue trigger function processed message: {Encoding.UTF8.GetString(args.Body)}");
         }
 
+        // This sample should fail when running a console app that sends out a message incorrectly formatted.
+        // It should add the message to the dead letter exchange called "dlxName"
         public static void RabbitMQTrigger_JsonToPOCO(
             [RabbitMQTrigger(connectionStringSetting: "rabbitMQ", "new_test_queue", "dlxName")] TestClass pocObj,
             ILogger logger)
@@ -106,13 +108,14 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
             logger.LogInformation($"RabbitMQ queue trigger function processed message: {pocObj}");
         }
 
+        // This sample waits on messages from the poison queue created by the above sample.
+        // It should process it correctly since it's configured to be of type string.
         public static void RabbitMQTrigger_JsonToPOCO_DeadLetter(
             [RabbitMQTrigger(connectionStringSetting: "rabbitMQ", "new_test_queue-poison")] string res,
             ILogger logger)
         {
             logger.LogInformation($"RabbitMQ queue trigger function processed message: {res}");
         }
-
 
         public static void RabbitMQTrigger_RabbitMQOutput(
             [RabbitMQTrigger("queue", "dlxName")] string inputMessage,
@@ -122,7 +125,7 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
             ILogger logger)
         {
             outputMessage = inputMessage;
-            logger.LogInformation($"RabittMQ output binding function sent message: {outputMessage}");
+            logger.LogInformation($"RabbitMQ output binding function sent message: {outputMessage}");
         }
 
         public class TestClass

--- a/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
@@ -77,7 +77,7 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
         // Trigger samples
         // Defaults to localhost if HostName is not specified and connection string is not set in appsettings.json
         public static void RabbitMQTrigger_String(
-             [RabbitMQTrigger("queue")] string message,
+             [RabbitMQTrigger(connectionStringSetting: "rabbitMQ", "new_test_queue", "dlxName")] string message,
              string consumerTag,
              ILogger logger)
         {
@@ -85,7 +85,7 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
         }
 
         public static void RabbitMQTrigger_String_NoConnectionString(
-             [RabbitMQTrigger(hostName: "RabbitMQHostName", userNameSetting: "%UserNameSetting%", passwordSetting: "%PasswordSetting%", port: 5672, queueName: "queue")] string message,
+             [RabbitMQTrigger(hostName: "RabbitMQHostName", userNameSetting: "%UserNameSetting%", passwordSetting: "%PasswordSetting%", port: 5672, queueName: "queue", deadLetterExchangeName: "dlxName")] string message,
              string consumerTag,
              ILogger logger)
         {
@@ -93,21 +93,21 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
         }
 
         public static void RabbitMQTrigger_BasicDeliverEventArgs(
-            [RabbitMQTrigger("queue")] BasicDeliverEventArgs args,
+            [RabbitMQTrigger("queue", "dlxName")] BasicDeliverEventArgs args,
             ILogger logger)
         {
             logger.LogInformation($"RabbitMQ queue trigger function processed message: {Encoding.UTF8.GetString(args.Body)}");
         }
 
         public static void RabbitMQTrigger_JsonToPOCO(
-            [RabbitMQTrigger("queue")] TestClass pocObj,
+            [RabbitMQTrigger(connectionStringSetting: "rabbitMQ", "new_test_queue", "dlxName")] TestClass pocObj,
             ILogger logger)
         {
             logger.LogInformation($"RabbitMQ queue trigger function processed message: {pocObj}");
         }
 
         public static void RabbitMQTrigger_RabbitMQOutput(
-            [RabbitMQTrigger("queue")] string inputMessage,
+            [RabbitMQTrigger("queue", "dlxName")] string inputMessage,
             [RabbitMQ(
                 HostName = "localhost",
                 QueueName = "hello")] out string outputMessage,

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/testappsettings.json
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/testappsettings.json
@@ -1,5 +1,6 @@
 {
     "connectionStrings": {
+        "rabbitMQ": "amqp://guest:guest@localhost:5672",
         "rabbitMQTest": "amqp://guest:guest@tada:5672"
     }
 }


### PR DESCRIPTION
Adds poisoned messages delivered to the triggered queue to a dead letter exchange with the specified name. We make this attribute a requirement for the trigger binding, which means that the developer must configure their queue with the same dead letter exchange. 

As of now, I'm not making the dead letter exchange name required for the output binding, since the trigger in particular is what has to handle any message delivery issues.

Still trying to figure out how to verify that the poisoned messages are actually in the DLX. 