### PR TITLE
Only make queue and dlx required in constructor

### DIFF
--- a/src/Trigger/RabbitMQTriggerAttribute.cs
+++ b/src/Trigger/RabbitMQTriggerAttribute.cs
@@ -21,7 +21,16 @@ namespace Microsoft.Azure.WebJobs
             DeadLetterExchangeName = deadLetterExchangeName;
         }
 
-        public RabbitMQTriggerAttribute(string hostName, string userNameSetting, string passwordSetting, int port, string queueName, string deadLetterExchangeName = "")
+        public RabbitMQTriggerAttribute(string hostName, string userNameSetting, string passwordSetting, int port, string queueName)
+        {
+            HostName = hostName;
+            UserNameSetting = userNameSetting;
+            PasswordSetting = passwordSetting;
+            Port = port;
+            QueueName = queueName;
+        }
+
+        public RabbitMQTriggerAttribute(string hostName, string userNameSetting, string passwordSetting, int port, string queueName, string deadLetterExchangeName)
         {
             HostName = hostName;
             UserNameSetting = userNameSetting;

--- a/src/Trigger/RabbitMQTriggerAttribute.cs
+++ b/src/Trigger/RabbitMQTriggerAttribute.cs
@@ -15,12 +15,6 @@ namespace Microsoft.Azure.WebJobs
             QueueName = queueName;
         }
 
-        public RabbitMQTriggerAttribute(string queueName, string deadLetterExchangeName)
-        {
-            QueueName = queueName;
-            DeadLetterExchangeName = deadLetterExchangeName;
-        }
-
         public RabbitMQTriggerAttribute(string hostName, string userNameSetting, string passwordSetting, int port, string queueName)
         {
             HostName = hostName;
@@ -28,16 +22,6 @@ namespace Microsoft.Azure.WebJobs
             PasswordSetting = passwordSetting;
             Port = port;
             QueueName = queueName;
-        }
-
-        public RabbitMQTriggerAttribute(string hostName, string userNameSetting, string passwordSetting, int port, string queueName, string deadLetterExchangeName)
-        {
-            HostName = hostName;
-            UserNameSetting = userNameSetting;
-            PasswordSetting = passwordSetting;
-            Port = port;
-            QueueName = queueName;
-            DeadLetterExchangeName = deadLetterExchangeName;
         }
 
         [ConnectionString]
@@ -55,6 +39,6 @@ namespace Microsoft.Azure.WebJobs
 
         public int Port { get; set; }
 
-        public string DeadLetterExchangeName { get; }
+        public string DeadLetterExchangeName { get; set; }
     }
 }

--- a/src/Trigger/RabbitMQTriggerAttribute.cs
+++ b/src/Trigger/RabbitMQTriggerAttribute.cs
@@ -9,15 +9,13 @@ namespace Microsoft.Azure.WebJobs
     [Binding]
     public sealed class RabbitMQTriggerAttribute : Attribute
     {
-        public RabbitMQTriggerAttribute(string connectionStringSetting, string queueName, string deadLetterExchangeName = "")
+
+        public RabbitMQTriggerAttribute(string queueName)
         {
-            ConnectionStringSetting = connectionStringSetting;
             QueueName = queueName;
-            DeadLetterExchangeName = deadLetterExchangeName;
         }
 
-
-        public RabbitMQTriggerAttribute(string queueName, string deadLetterExchangeName = "")
+        public RabbitMQTriggerAttribute(string queueName, string deadLetterExchangeName)
         {
             QueueName = queueName;
             DeadLetterExchangeName = deadLetterExchangeName;
@@ -34,19 +32,19 @@ namespace Microsoft.Azure.WebJobs
         }
 
         [ConnectionString]
-        public string ConnectionStringSetting { get; }
+        public string ConnectionStringSetting { get; set; }
 
-        public string HostName { get; }
+        public string HostName { get; set; }
 
         public string QueueName { get; }
 
         [AppSetting]
-        public string UserNameSetting { get; }
+        public string UserNameSetting { get; set; }
 
         [AppSetting]
-        public string PasswordSetting { get; }
+        public string PasswordSetting { get; set; }
 
-        public int Port { get; }
+        public int Port { get; set; }
 
         public string DeadLetterExchangeName { get; }
     }

--- a/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
@@ -96,7 +96,7 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
         }
 
         public static void RabbitMQTrigger_String_NoConnectionString(
-             [RabbitMQTrigger(hostName: "RabbitMQHostName", userNameSetting: "%UserNameSetting%", passwordSetting: "%PasswordSetting%", port: 5672, queueName: "queue", deadLetterExchangeName: "dlxName")] string message,
+             [RabbitMQTrigger(hostName: "RabbitMQHostName", userNameSetting: "%UserNameSetting%", passwordSetting: "%PasswordSetting%", port: 5672, queueName: "queue", DeadLetterExchangeName = "dlxName")] string message,
              string consumerTag,
              ILogger logger)
         {
@@ -104,7 +104,7 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
         }
 
         public static void RabbitMQTrigger_BasicDeliverEventArgs(
-            [RabbitMQTrigger("queue", "dlxName")] BasicDeliverEventArgs args,
+            [RabbitMQTrigger("queue", DeadLetterExchangeName = "dlxName")] BasicDeliverEventArgs args,
             ILogger logger)
         {
             logger.LogInformation($"RabbitMQ queue trigger function processed message: {Encoding.UTF8.GetString(args.Body)}");
@@ -113,7 +113,7 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
         // This sample should fail when running a console app that sends out a message incorrectly formatted.
         // It should add the message to the dead letter exchange called "dlxName"
         public static void RabbitMQTrigger_JsonToPOCO(
-            [RabbitMQTrigger("new_test_queue", "dlxName", ConnectionStringSetting = "rabbitMQ")] TestClass pocObj,
+            [RabbitMQTrigger("new_test_queue", DeadLetterExchangeName = "dlxName", ConnectionStringSetting = "rabbitMQ")] TestClass pocObj,
             ILogger logger)
         {
             logger.LogInformation($"RabbitMQ queue trigger function processed message: {pocObj}");
@@ -129,7 +129,7 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
         }
 
         public static void RabbitMQTrigger_RabbitMQOutput(
-            [RabbitMQTrigger("queue", "dlxName")] string inputMessage,
+            [RabbitMQTrigger("queue", DeadLetterExchangeName = "dlxName")] string inputMessage,
             [RabbitMQ(
                 HostName = "localhost",
                 QueueName = "hello")] out string outputMessage,

--- a/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
@@ -87,9 +87,8 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
         }
 
         // Trigger samples
-        // Defaults to localhost if HostName is not specified and connection string is not set in appsettings.json
         public static void RabbitMQTrigger_String(
-             [RabbitMQTrigger(connectionStringSetting: "rabbitMQ", "new_test_queue", "dlxName")] string message,
+             [RabbitMQTrigger("new_test_queue", ConnectionStringSetting = "rabbitMQ")] string message,
              string consumerTag,
              ILogger logger)
         {
@@ -114,7 +113,7 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
         // This sample should fail when running a console app that sends out a message incorrectly formatted.
         // It should add the message to the dead letter exchange called "dlxName"
         public static void RabbitMQTrigger_JsonToPOCO(
-            [RabbitMQTrigger(connectionStringSetting: "rabbitMQ", "new_test_queue", "dlxName")] TestClass pocObj,
+            [RabbitMQTrigger("new_test_queue", "dlxName", ConnectionStringSetting = "rabbitMQ")] TestClass pocObj,
             ILogger logger)
         {
             logger.LogInformation($"RabbitMQ queue trigger function processed message: {pocObj}");
@@ -123,7 +122,7 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
         // This sample waits on messages from the poison queue created by the above sample.
         // It should process it correctly since it's configured to be of type string.
         public static void RabbitMQTrigger_Process_PoisonQueue(
-            [RabbitMQTrigger(connectionStringSetting: "rabbitMQ", "new_test_queue-poison")] string res,
+            [RabbitMQTrigger("new_test_queue-poison", ConnectionStringSetting = "rabbitMQ")] string res,
             ILogger logger)
         {
             logger.LogInformation($"RabbitMQ queue trigger function processed message: {res}");


### PR DESCRIPTION
https://github.com/Azure/azure-functions-rabbitmq-extension/issues/63

Looking at the other extensions, we decided to go with only two overloaded constructors (one that takes in the queue name and one that takes in the queue name + dlx name). Other properties, including the connection string, will then be optional and manually set by the user. Example:

```C#
 public static void RabbitMQTrigger_String(
             [RabbitMQTrigger("new_test_queue", ConnectionStringSetting = "rabbitMQ")] string message,
             string consumerTag,
             ILogger logger)
        {
            logger.LogInformation($"RabbitMQ queue trigger function processed message: {message} and consumer tag: {consumerTag}");
        }
```