### PR TITLE
Support for the Header Exchange trigger binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ To get started with developing with this extension, make sure you first [set up 
 
 See the repository [wiki](https://github.com/Azure/azure-functions-rabbitmq-extension/wiki) for more detailed samples of bindings to different types.
 
+## Queue Trigger and Output
+
 ```C#
 public static void RabbitMQTrigger_RabbitMQOutput(
     [RabbitMQTrigger("queue", ConnectionStringSetting = "RabbitMQConnection")] string inputMessage,
@@ -29,6 +31,8 @@ public static void RabbitMQTrigger_RabbitMQOutput(
 ```
 
 The above sample waits on a trigger from the queue named "queue" connected to the connection string value of key "RabbitMQConnection." The output binding takes the messages from the trigger queue and outputs them to queue "hello" connected to the connection configured by the key "RabibtMQConnection". When running locally, add the connection string setting to local.settings.json file. When running in Azure, add this setting as [Application Setting](https://docs.microsoft.com/en-us/azure/azure-functions/functions-how-to-use-azure-function-app-settings) for your app.
+
+## Header Exchange Trigger
 
 ```C#
 public static void RabbitMQTrigger_HeadersExchange(
@@ -54,11 +58,13 @@ If an x-match binding is not specified as per the RabbitMQ spec then all events 
 
 ### Queue Trigger Properties
 |Property Name|Description|Example|
+|--|--|--|
 |QueueName|The name of the source or destination queue|`myQueue`|
 |DeadLetterExchangeName|The name of the deadletter exchange for poison queue patterns|`dtxExchange`|
 
 ### Header Exchange Trigger Properties
 |Property Name|Description|Example|
+|--|--|--|
 |ExchangeName|The name of the source or destination queue|`myExchange`|
 |XMatch|Many any or all of the headers specified in the arguments|`any`|
 |Arguments|The headers to filter on if specified|`"{\"HeaderKey\":\"HeaderValue\"}"`|

--- a/README.md
+++ b/README.md
@@ -30,17 +30,38 @@ public static void RabbitMQTrigger_RabbitMQOutput(
 
 The above sample waits on a trigger from the queue named "queue" connected to the connection string value of key "RabbitMQConnection." The output binding takes the messages from the trigger queue and outputs them to queue "hello" connected to the connection configured by the key "RabibtMQConnection". When running locally, add the connection string setting to local.settings.json file. When running in Azure, add this setting as [Application Setting](https://docs.microsoft.com/en-us/azure/azure-functions/functions-how-to-use-azure-function-app-settings) for your app.
 
+```C#
+public static void RabbitMQTrigger_HeadersExchange(
+    [RabbitMQTrigger("headersExchange", "all", "{\"HeaderKey1\":\"fba410d3-b9bd-40c3-8e6c-d76981cd64af\",\"HeaderKey2\":\"events\"}", ConnectionStringSetting = "RabbitMQConnection")] string inputMessage,
+    ILogger logger)
+{    
+    logger.LogInformation($"RabittMQ header exchange input binding function received message: {intputMessage}");
+}
+```
+
+The above sample waits on a trigger from an exchange named "headersExchange" connected to the connection string value of key "RabbitMQConnection.".
+This uses an x-match binding of "all" for the arguments "HeaderKey1" and "HeaderKey2", which for this example means that only events with the matching header keys will be received. 
+If an x-match binding is not specified as per the RabbitMQ spec then all events will be received.
 
 ## Properties
 
 |Property Name|Description|Example|
 |--|--|--|
 |ConnectionStringSetting|The connection string for the RabbitMQ queue|`amqp://user:password@url:port`|
-|QueueName|The name of the source or destination queue|`myQueue`|
-|DeadLetterExchangeName|The name of the deadletter exchange for poison queue patterns|`dtxExchange`|
 |HostName|(optional if using ConnectionStringSetting) Hostname of the queue|`10.26.45.210`|
 |UserName|(optional if using ConnectionStringSetting) User name to access queue|`user`|
 |Password|(optional if using ConnectionStringSetting) Password to access queue|`password1`|
+
+### Queue Trigger Properties
+|Property Name|Description|Example|
+|QueueName|The name of the source or destination queue|`myQueue`|
+|DeadLetterExchangeName|The name of the deadletter exchange for poison queue patterns|`dtxExchange`|
+
+### Header Exchange Trigger Properties
+|Property Name|Description|Example|
+|ExchangeName|The name of the source or destination queue|`myExchange`|
+|XMatch|Many any or all of the headers specified in the arguments|`any`|
+|Arguments|The headers to filter on if specified|`"{\"HeaderKey\":\"HeaderValue\"}"`|
 
 # Contributing
 

--- a/src/Config/DefaultRabbitMQServiceFactory.cs
+++ b/src/Config/DefaultRabbitMQServiceFactory.cs
@@ -14,5 +14,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         {
             return new RabbitMQService(connectionString, hostName, userName, password, port);
         }
+
+        public IRabbitMQService CreateService(string connectionString, string hostName, string exchangeName, string xMatch, string arguments, string userName, string password, int port)
+        {
+            return new RabbitMQService(connectionString, hostName, exchangeName, xMatch, arguments, userName, password, port);
+        }
     }
 }

--- a/src/Config/IRabbitMQServiceFactory.cs
+++ b/src/Config/IRabbitMQServiceFactory.cs
@@ -6,7 +6,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
     public interface IRabbitMQServiceFactory
     {
         IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port, string deadLetterExchangeName);
+
         IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port);
 
+        IRabbitMQService CreateService(string connectionString, string hostName, string exchangeName, string xMatch, string arguments, string userName, string password, int port);
     }
 }

--- a/src/Config/RabbitMQExtensionConfigProvider.cs
+++ b/src/Config/RabbitMQExtensionConfigProvider.cs
@@ -90,9 +90,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             string queueName = Utility.FirstOrDefault(attribute.QueueName, _options.Value.QueueName);
             string userName = Utility.FirstOrDefault(attribute.UserName, _options.Value.UserName);
             string password = Utility.FirstOrDefault(attribute.Password, _options.Value.Password);
+            string exchangeName = Utility.FirstOrDefault(attribute.ExchangeName, _options.Value.ExchangeName);
+            string xMatch = Utility.FirstOrDefault(attribute.XMatch, _options.Value.XMatch);
+            string arguments = Utility.FirstOrDefault(attribute.Arguments, _options.Value.Arguments);
             int port = Utility.FirstOrDefault(attribute.Port, _options.Value.Port);
             string deadLetterExchangeName = Utility.FirstOrDefault(attribute.DeadLetterExchangeName, _options.Value.DeadLetterExchangeName);
-
 
             RabbitMQAttribute resolvedAttribute;
             IRabbitMQService service;
@@ -106,9 +108,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 Password = password,
                 Port = port,
                 DeadLetterExchangeName = deadLetterExchangeName,
+                XMatch = xMatch,
+                ExchangeName = exchangeName,
+                Arguments = arguments,
             };
 
-            service = GetService(connectionString, hostName, queueName, userName, password, port, deadLetterExchangeName);
+            service = string.IsNullOrWhiteSpace(exchangeName) ?
+                GetService(connectionString, hostName, queueName, userName, password, port, deadLetterExchangeName) :
+                GetService(connectionString, hostName, exchangeName, xMatch, arguments, userName, password, port);
 
             return new RabbitMQContext
             {
@@ -120,6 +127,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         internal IRabbitMQService GetService(string connectionString, string hostName, string queueName, string userName, string password, int port, string deadLetterExchangeName)
         {
             return _rabbitMQServiceFactory.CreateService(connectionString, hostName, queueName, userName, password, port, deadLetterExchangeName);
+        }
+
+        internal IRabbitMQService GetService(string connectionString, string hostName, string exchangeName, string xMatch, string arguments, string userName, string password, int port)
+        {
+            return _rabbitMQServiceFactory.CreateService(connectionString, hostName, exchangeName, xMatch, arguments, userName, password, port);
         }
 
         // Overloaded method used only for getting the RabbitMQ client

--- a/src/Config/RabbitMQOptions.cs
+++ b/src/Config/RabbitMQOptions.cs
@@ -21,5 +21,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         public int Port { get; set; }
 
         public string DeadLetterExchangeName { get; set; }
+
+        public string ExchangeName { get; set; }
+
+        public string XMatch { get; set; }
+
+        public string Arguments { get; set; }
     }
 }

--- a/src/RabbitMQAttribute.cs
+++ b/src/RabbitMQAttribute.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.Azure.WebJobs.Description;
-using RabbitMQ.Client;
 
 namespace Microsoft.Azure.WebJobs
 {
@@ -43,5 +42,14 @@ namespace Microsoft.Azure.WebJobs
 
         [AutoResolve]
         public string DeadLetterExchangeName { get; set; }
+
+        [AutoResolve]
+        public string ExchangeName { get; set; }
+
+        [AutoResolve]
+        public string XMatch { get; set; }
+
+        [AutoResolve]
+        public string Arguments { get; set; }
     }
 }

--- a/src/Trigger/RabbitMQModel.cs
+++ b/src/Trigger/RabbitMQModel.cs
@@ -39,6 +39,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
         public string BasicConsume(string queue, bool autoAck, IBasicConsumer consumer)
         {
+            if (string.IsNullOrEmpty(queue))
+            {
+                queue = string.Empty;
+            }
+
             return _model.BasicConsume(queue, autoAck, consumer);
         }
 

--- a/src/Trigger/RabbitMQTriggerAttribute.cs
+++ b/src/Trigger/RabbitMQTriggerAttribute.cs
@@ -15,6 +15,13 @@ namespace Microsoft.Azure.WebJobs
             QueueName = queueName;
         }
 
+        public RabbitMQTriggerAttribute(string exchangeName, string xMatch, string arguments)
+        {
+            ExchangeName = exchangeName;
+            XMatch = xMatch;
+            Arguments = arguments;
+        }
+
         public RabbitMQTriggerAttribute(string hostName, string userNameSetting, string passwordSetting, int port, string queueName)
         {
             HostName = hostName;
@@ -40,5 +47,11 @@ namespace Microsoft.Azure.WebJobs
         public int Port { get; set; }
 
         public string DeadLetterExchangeName { get; set; }
+
+        public string ExchangeName { get; set; }
+
+        public string XMatch { get; set; }
+
+        public string Arguments { get; set; }
     }
 }

--- a/src/WebJobs.Extensions.RabbitMQ.csproj
+++ b/src/WebJobs.Extensions.RabbitMQ.csproj
@@ -45,6 +45,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.10" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
     <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQConfigProviderTests.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQConfigProviderTests.cs
@@ -47,7 +47,7 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
         [InlineData(Constants.LocalHost, "queue", null, null)]
         [InlineData(null, "hello", Constants.LocalHost, null)]
         [InlineData(null, null, Constants.LocalHost, "name")]
-        public void Handles_Null_Attributes_And_Options(string attrHostname, string attrQueueName, string optHostname, string optQueueName)
+        public void Handles_Null_Queue_Attributes_And_Options(string attrHostname, string attrQueueName, string optHostname, string optQueueName)
         {
             RabbitMQAttribute attr = new RabbitMQAttribute
             {
@@ -81,6 +81,69 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
             {
                 Assert.Equal(actualContext.ResolvedAttribute.HostName, optHostname);
                 Assert.Equal(actualContext.ResolvedAttribute.QueueName, optQueueName);
+            }
+        }
+
+        [Theory]
+        [InlineData("exchange", "any", "test", null, null, null)]
+        [InlineData("exchange", "any", null, null, null, "test")]
+        [InlineData("exchange", null, "test", null, "any", null)]
+        [InlineData("exchange", null, null, null, "any", "test")]
+        [InlineData(null, "any", "test", "exchange", null, null)]
+        [InlineData(null, null, "test", "exchange", "any", null)]
+        [InlineData(null, "any", null, "exchange", null, "test")]
+        [InlineData(null, null, null, "exchange", "any", "test")]
+        public void Handles_Null_Exchange_Attributes_And_Options(string attrExchangeName, string attrXMatch, string attrArguments, 
+            string optExchangeName, string optXMatch, string optArguments)
+        {
+            RabbitMQAttribute attr = new RabbitMQAttribute
+            {
+                ExchangeName = attrExchangeName,
+                XMatch = attrXMatch,
+                Arguments = attrArguments
+            };
+
+            RabbitMQOptions opt = new RabbitMQOptions
+            {
+                ExchangeName = optExchangeName,
+                XMatch = optXMatch,
+                Arguments = optArguments
+            };
+
+            var loggerFactory = new LoggerFactory();
+            var mockServiceFactory = new Mock<IRabbitMQServiceFactory>();
+            var mockNameResolver = new Mock<INameResolver>();
+            var config = new RabbitMQExtensionConfigProvider(new OptionsWrapper<RabbitMQOptions>(opt), mockNameResolver.Object, mockServiceFactory.Object, (ILoggerFactory)loggerFactory, _emptyConfig);
+            var actualContext = config.CreateContext(attr);
+
+            if (attrExchangeName == null)
+            {
+                Assert.Equal(actualContext.ResolvedAttribute.ExchangeName, optExchangeName);
+            }
+
+            if (attrXMatch == null)
+            {
+                Assert.Equal(actualContext.ResolvedAttribute.XMatch, optXMatch);
+            }
+
+            if (attrArguments == null)
+            {
+                Assert.Equal(actualContext.ResolvedAttribute.Arguments, optArguments);
+            }
+
+            if (optExchangeName == null)
+            {
+                Assert.Equal(actualContext.ResolvedAttribute.ExchangeName, attrExchangeName);
+            }
+
+            if (optXMatch == null)
+            {
+                Assert.Equal(actualContext.ResolvedAttribute.XMatch, attrXMatch);
+            }
+
+            if (optArguments == null)
+            {
+                Assert.Equal(actualContext.ResolvedAttribute.Arguments, attrArguments);
             }
         }
     }


### PR DESCRIPTION
One of the concepts supported by RabbitMQ is the "Headers Exchange".
You can read more on this here: https://www.rabbitmq.com/tutorials/amqp-concepts.html

This pull request modifies the existing binding to add support for specifying an exchange instead of a queue. In the RabbitMQ Service this will create a queue based on the exchange name and bind based on specified x-match headers with supplied arguments.

I'm looking to use this in an upcoming project that relies heavily on this methodology, by spinning up several functions that will listen to their own specific headers independently of each other.

I appreciate the work you have done so far and look forward to seeing how I can help extend the functionality of this extension!