### PR TITLE
Added ability to set a custom routing key per message

### DIFF
--- a/src/Bindings/RabbitMQAsyncCollector.cs
+++ b/src/Bindings/RabbitMQAsyncCollector.cs
@@ -9,7 +9,7 @@ using RabbitMQ.Client;
 
 namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
-    internal class RabbitMQAsyncCollector : IAsyncCollector<byte[]>
+    internal class RabbitMQAsyncCollector : IAsyncCollector<RabbitMQMessage>
     {
         private readonly RabbitMQContext _context;
         private readonly IBasicPublishBatch _batch;
@@ -28,9 +28,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             _batch = _context.Service.BasicPublishBatch;
         }
 
-        public Task AddAsync(byte[] message, CancellationToken cancellationToken = default)
+        public Task AddAsync(RabbitMQMessage message, CancellationToken cancellationToken = default)
         {
-            _batch.Add(exchange: string.Empty, routingKey: _context.ResolvedAttribute.QueueName, mandatory: false, properties: null, body: message);
+            _batch.Add(exchange: string.Empty, routingKey: message.RoutingKey ?? _context.ResolvedAttribute.QueueName, mandatory: false, properties: null, body: message.Body);
             _logger.LogDebug($"Adding message to batch for publishing...");
 
             return Task.CompletedTask;

--- a/src/Config/RabbitMQExtensionConfigProvider.cs
+++ b/src/Config/RabbitMQExtensionConfigProvider.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
             var rule = context.AddBindingRule<RabbitMQAttribute>();
             rule.AddValidator(ValidateBinding);
-            rule.BindToCollector<byte[]>((attr) =>
+            rule.BindToCollector((attr) =>
             {
                 return new RabbitMQAsyncCollector(CreateContext(attr), _logger);
             });

--- a/src/RabbitMQMessage.cs
+++ b/src/RabbitMQMessage.cs
@@ -1,0 +1,14 @@
+﻿namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
+{
+    public class RabbitMQMessage
+    {
+        public RabbitMQMessage(byte[] body)
+        {
+            Body = body;
+        }
+
+        public byte[] Body { get; set; }
+
+        public string RoutingKey { get; set; }
+    }
+}

--- a/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
@@ -51,12 +51,12 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
         // So you can add items to the queue while the sample is running, and the trigger will be called until the queue is empty.
         public static async Task ProcessMessage_RabbitMQAsyncCollector(
             [QueueTrigger(@"samples-rabbitmq-messages")] string message,
-            [RabbitMQ(QueueName = "queue")] IAsyncCollector<byte[]> messages,
+            [RabbitMQ(QueueName = "queue")] IAsyncCollector<RabbitMQMessage> messages,
             ILogger logger)
         {
             logger.LogInformation($"Received queue trigger");
             byte[] messageInBytes = Encoding.UTF8.GetBytes(message);
-            await messages.AddAsync(messageInBytes);
+            await messages.AddAsync(new RabbitMQMessage(messageInBytes) { RoutingKey = "custom-routing-key" });
         }
 
         // To run:

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQAsyncCollectorTests.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQAsyncCollectorTests.cs
@@ -40,7 +40,7 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
             var collector = new RabbitMQAsyncCollector(context, logger);
 
             byte[] body = Encoding.UTF8.GetBytes("hi");
-            await collector.AddAsync(body);
+            await collector.AddAsync(new RabbitMQMessage(body));
 
             mockBatch.Verify(m => m.Add(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<IBasicProperties>(), body), Times.Exactly(1));
         }


### PR DESCRIPTION
As discussed in #51, it is an extremely common requirement to set a routing key of a message based on, for example it's content. The current implementation sets the routing key to the `QueueName`.

This PR proposes an abstraction in the generic of the `IAsyncCollector` implementation which enables common meta data related to the message body to be expressed, in this case the `RoutingKey`.

This is an optional property, and is only used if it is explicitly defined, else normal operation resumes.