### PR TITLE
Removed the hard coded durability values on QueueDeclare

### DIFF
--- a/src/Config/DefaultRabbitMQServiceFactory.cs
+++ b/src/Config/DefaultRabbitMQServiceFactory.cs
@@ -5,9 +5,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     internal class DefaultRabbitMQServiceFactory : IRabbitMQServiceFactory
     {
-        public IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port, string deadLetterExchangeName)
+        public IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port, string deadLetterExchangeName, bool isDurable, bool isDeadLetterExchangeDurable)
         {
-            return new RabbitMQService(connectionString, hostName, queueName, userName, password, port, deadLetterExchangeName);
+            return new RabbitMQService(connectionString, hostName, queueName, userName, password, port, deadLetterExchangeName, isDurable, isDeadLetterExchangeDurable);
         }
 
         public IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port)

--- a/src/Config/IRabbitMQServiceFactory.cs
+++ b/src/Config/IRabbitMQServiceFactory.cs
@@ -5,7 +5,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     public interface IRabbitMQServiceFactory
     {
-        IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port, string deadLetterExchangeName);
+        IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port, string deadLetterExchangeName, bool isDurable, bool isDeadLetterExchangeDurable);
+
         IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port);
     }
 }

--- a/src/Config/RabbitMQExtensionConfigProvider.cs
+++ b/src/Config/RabbitMQExtensionConfigProvider.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 DeadLetterExchangeName = deadLetterExchangeName,
             };
 
-            service = GetService(connectionString, hostName, queueName, userName, password, port, deadLetterExchangeName);
+            service = GetService(connectionString, hostName, queueName, userName, password, port, deadLetterExchangeName, attribute.IsDurable, attribute.IsDeadLetterExchangeDurable);
 
             return new RabbitMQContext
             {
@@ -117,9 +117,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             };
         }
 
-        internal IRabbitMQService GetService(string connectionString, string hostName, string queueName, string userName, string password, int port, string deadLetterExchangeName)
+        internal IRabbitMQService GetService(
+            string connectionString,
+            string hostName,
+            string queueName,
+            string userName,
+            string password,
+            int port,
+            string deadLetterExchangeName,
+            bool isDurable,
+            bool isDeadLetterExchangeDurable)
         {
-            return _rabbitMQServiceFactory.CreateService(connectionString, hostName, queueName, userName, password, port, deadLetterExchangeName);
+            return _rabbitMQServiceFactory.CreateService(connectionString, hostName, queueName, userName, password, port, deadLetterExchangeName, isDurable, isDeadLetterExchangeDurable);
         }
 
         // Overloaded method used only for getting the RabbitMQ client

--- a/src/RabbitMQAttribute.cs
+++ b/src/RabbitMQAttribute.cs
@@ -35,6 +35,8 @@ namespace Microsoft.Azure.WebJobs
         [AppSetting]
         public string Password { get; set; }
 
+        public bool IsDurable { get; set; }
+
         // Optional
         public int Port { get; set; }
 
@@ -43,5 +45,7 @@ namespace Microsoft.Azure.WebJobs
 
         [AutoResolve]
         public string DeadLetterExchangeName { get; set; }
+
+        public bool IsDeadLetterExchangeDurable { get; set; }
     }
 }

--- a/src/Services/RabbitMQService.cs
+++ b/src/Services/RabbitMQService.cs
@@ -39,7 +39,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             _model = connectionFactory.CreateConnection().CreateModel();
         }
 
-        public RabbitMQService(string connectionString, string hostName, string queueName, string userName, string password, int port, string deadLetterExchangeName)
+        public RabbitMQService(
+            string connectionString,
+            string hostName,
+            string queueName,
+            string userName,
+            string password,
+            int port,
+            string deadLetterExchangeName,
+            bool isDurable,
+            bool isDeadLetterExchangeDurable)
             : this(connectionString, hostName, userName, password, port)
         {
             _rabbitMQModel = new RabbitMQModel(_model);
@@ -53,7 +62,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             if (!string.IsNullOrEmpty(_deadLetterExchangeName))
             {
                 string deadLetterQueueName = string.Format("{0}-poison", _queueName);
-                _model.QueueDeclare(queue: deadLetterQueueName, durable: false, exclusive: false, autoDelete: false, arguments: null);
+                _model.QueueDeclare(queue: deadLetterQueueName, isDeadLetterExchangeDurable, exclusive: false, autoDelete: false, arguments: null);
                 _model.ExchangeDeclare(_deadLetterExchangeName, Constants.DefaultDLXSetting);
                 _model.QueueBind(deadLetterQueueName, _deadLetterExchangeName, Constants.DeadLetterRoutingKeyValue, null);
 
@@ -61,7 +70,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 args[Constants.DeadLetterRoutingKey] = Constants.DeadLetterRoutingKeyValue;
             }
 
-            _model.QueueDeclare(queue: _queueName, durable: false, exclusive: false, autoDelete: false, arguments: args);
+            _model.QueueDeclare(queue: _queueName, isDurable, exclusive: false, autoDelete: false, arguments: args);
             _batch = _model.CreateBasicPublishBatch();
         }
 

--- a/src/Trigger/RabbitMQTriggerAttribute.cs
+++ b/src/Trigger/RabbitMQTriggerAttribute.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Azure.WebJobs
     [Binding]
     public sealed class RabbitMQTriggerAttribute : Attribute
     {
-
         public RabbitMQTriggerAttribute(string queueName)
         {
             QueueName = queueName;
@@ -22,6 +21,20 @@ namespace Microsoft.Azure.WebJobs
             PasswordSetting = passwordSetting;
             Port = port;
             QueueName = queueName;
+        }
+
+        public RabbitMQTriggerAttribute(
+           string hostName,
+           string userNameSetting,
+           string passwordSetting,
+           int port,
+           string queueName,
+           bool isDurable,
+           bool isDeadLetterExchangeDurable)
+           : this(hostName, userNameSetting, passwordSetting, port, queueName)
+        {
+            IsDurable = isDurable;
+            IsDeadLetterExchangeDurable = isDeadLetterExchangeDurable;
         }
 
         [ConnectionString]
@@ -37,8 +50,12 @@ namespace Microsoft.Azure.WebJobs
         [AppSetting]
         public string PasswordSetting { get; set; }
 
+        public bool IsDurable { get; set; }
+
         public int Port { get; set; }
 
         public string DeadLetterExchangeName { get; set; }
+
+        public bool IsDeadLetterExchangeDurable { get; set; }
     }
 }

--- a/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
+++ b/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 throw new InvalidOperationException("RabbitMQ username and password required if not connecting to localhost");
             }
 
-            IRabbitMQService service = _provider.GetService(connectionString, hostName, queueName, userName, password, port, deadLetterExchangeName);
+            IRabbitMQService service = _provider.GetService(connectionString, hostName, queueName, userName, password, port, deadLetterExchangeName, attribute.IsDurable, attribute.IsDeadLetterExchangeDurable);
 
             return Task.FromResult<ITriggerBinding>(new RabbitMQTriggerBinding(service, hostName, queueName, _logger));
         }


### PR DESCRIPTION
Verified to be working with a local rabbitmq instance and a durable queue. Also validated it blows up if durable = true is specified in the attribute and the queue durability is false

I purposefully didn't support configuration values for this because it would not be known which value to use in case config values and attribute values are used at the same time. 