### PR TITLE
Cofiguration extending

### DIFF
--- a/src/Bindings/RabbitMQAsyncCollector.cs
+++ b/src/Bindings/RabbitMQAsyncCollector.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
         public Task AddAsync(byte[] message, CancellationToken cancellationToken = default)
         {
+            //TODO: Should we publish into exchange instead?
             _batch.Add(exchange: string.Empty, routingKey: _context.ResolvedAttribute.QueueName, mandatory: false, properties: null, body: message);
             _logger.LogDebug($"Adding message to batch for publishing...");
 

--- a/src/Config/DefaultRabbitMQServiceFactory.cs
+++ b/src/Config/DefaultRabbitMQServiceFactory.cs
@@ -5,14 +5,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     internal class DefaultRabbitMQServiceFactory : IRabbitMQServiceFactory
     {
-        public IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port, string deadLetterExchangeName)
+        public IRabbitMQService CreateService(string connectionString, QueueConfiguration config)
         {
-            return new RabbitMQService(connectionString, hostName, queueName, userName, password, port, deadLetterExchangeName);
+            return new RabbitMQService(connectionString, config);
         }
 
-        public IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port)
+        public IRabbitMQService CreateService(string connectionString)
         {
-            return new RabbitMQService(connectionString, hostName, userName, password, port);
+            return new RabbitMQService(connectionString);
         }
     }
 }

--- a/src/Config/IRabbitMQServiceFactory.cs
+++ b/src/Config/IRabbitMQServiceFactory.cs
@@ -5,7 +5,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     public interface IRabbitMQServiceFactory
     {
-        IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port, string deadLetterExchangeName);
-        IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port);
+        IRabbitMQService CreateService(string connectionString, QueueConfiguration config);
+
+        IRabbitMQService CreateService(string connectionString);
     }
 }

--- a/src/Config/RabbitMQOptions.cs
+++ b/src/Config/RabbitMQOptions.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Microsoft.Azure.WebJobs.Description;
-using RabbitMQ.Client;
-
 namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     public class RabbitMQOptions
@@ -21,5 +18,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         public int Port { get; set; }
 
         public string DeadLetterExchangeName { get; set; }
+
+        public RabbitMqTriggerOptions Trigger { get; set; }
     }
 }

--- a/src/Config/RabbitMqTriggerOptions.cs
+++ b/src/Config/RabbitMqTriggerOptions.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
+{
+    public class RabbitMqTriggerOptions
+    {
+        public ushort PrefetchCount { get; set; }
+
+        public bool IsDurableQueue { get; set; }
+
+        public bool IsExclusiveQueue { get; set; }
+
+        public bool IsAutoDeleteQueue { get; set; }
+
+        public bool IsLazyQueue { get; set; }
+    }
+}

--- a/src/Constants.cs
+++ b/src/Constants.cs
@@ -9,5 +9,9 @@
         public const string DefaultDLXSetting = "direct";
         public const string DeadLetterRoutingKey = "x-dead-letter-routing-key";
         public const string DeadLetterRoutingKeyValue = "poison-queue";
+        public const string DefaultUsername = "guest";
+        public const string DefaultPassword = "guest";
+        public const int DefaultPort = 5672;
+        public const ushort PrefetchCountDefault = 8;
     }
 }

--- a/src/Services/RabbitMQService.cs
+++ b/src/Services/RabbitMQService.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using RabbitMQ.Client;
 
 namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
@@ -12,13 +13,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         private IRabbitMQModel _rabbitMQModel;
         private IModel _model;
         private IBasicPublishBatch _batch;
-        private string _connectionString;
-        private string _hostName;
-        private string _queueName;
-        private string _userName;
-        private string _password;
-        private int _port;
-        private string _deadLetterExchangeName;
 
         public IRabbitMQModel RabbitMQModel => _rabbitMQModel;
 
@@ -26,76 +20,51 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
         public IBasicPublishBatch BasicPublishBatch => _batch;
 
-        public RabbitMQService(string connectionString, string hostName, string userName, string password, int port)
+        public RabbitMQService(string connectionString)
         {
-            _connectionString = connectionString;
-            _hostName = hostName;
-            _userName = userName;
-            _password = password;
-            _port = port;
-
-            ConnectionFactory connectionFactory = GetConnectionFactory(_connectionString, _hostName, _userName, _password, _port);
+            ConnectionFactory connectionFactory = GetConnectionFactory(connectionString);
 
             _model = connectionFactory.CreateConnection().CreateModel();
         }
 
-        public RabbitMQService(string connectionString, string hostName, string queueName, string userName, string password, int port, string deadLetterExchangeName)
-            : this(connectionString, hostName, userName, password, port)
+        public RabbitMQService(string connectionString, QueueConfiguration queueConfig)
+            : this(connectionString)
         {
             _rabbitMQModel = new RabbitMQModel(_model);
 
-            _deadLetterExchangeName = deadLetterExchangeName;
-            _queueName = queueName ?? throw new ArgumentNullException(nameof(queueName));
+            var deadLetterExchangeName = queueConfig.DeadLetterExchangeName;
+            var queueName = queueConfig.Name ?? throw new ArgumentNullException(nameof(queueConfig.Name));
 
-            Dictionary<string, object> args = new Dictionary<string, object>();
+            Dictionary<string, object> args = queueConfig.Arguments.ToDictionary(k => k.Key, k => k.Value);
 
             // Create dead letter queue
-            if (!string.IsNullOrEmpty(_deadLetterExchangeName))
+            if (!string.IsNullOrEmpty(deadLetterExchangeName))
             {
-                string deadLetterQueueName = string.Format("{0}-poison", _queueName);
+                string deadLetterQueueName = string.Format("{0}-poison", queueName);
                 _model.QueueDeclare(queue: deadLetterQueueName, durable: false, exclusive: false, autoDelete: false, arguments: null);
-                _model.ExchangeDeclare(_deadLetterExchangeName, Constants.DefaultDLXSetting);
-                _model.QueueBind(deadLetterQueueName, _deadLetterExchangeName, Constants.DeadLetterRoutingKeyValue, null);
+                _model.ExchangeDeclare(deadLetterExchangeName, Constants.DefaultDLXSetting);
+                _model.QueueBind(deadLetterQueueName, deadLetterExchangeName, Constants.DeadLetterRoutingKeyValue, null);
 
-                args[Constants.DeadLetterExchangeKey] = _deadLetterExchangeName;
+                args[Constants.DeadLetterExchangeKey] = deadLetterExchangeName;
                 args[Constants.DeadLetterRoutingKey] = Constants.DeadLetterRoutingKeyValue;
             }
 
-            _model.QueueDeclare(queue: _queueName, durable: false, exclusive: false, autoDelete: false, arguments: args);
+            _model.QueueDeclare(
+                queueName,
+                durable: queueConfig.Durable,
+                exclusive: queueConfig.Exclusive,
+                autoDelete: queueConfig.AutoDelete,
+                arguments: args);
             _batch = _model.CreateBasicPublishBatch();
         }
 
-        internal static ConnectionFactory GetConnectionFactory(string connectionString, string hostName, string userName, string password, int port)
+        internal static ConnectionFactory GetConnectionFactory(string connectionString)
         {
-            ConnectionFactory connectionFactory = new ConnectionFactory();
-
-            // Only set these if specified by user. Otherwise, API will use default parameters.
-            if (!string.IsNullOrEmpty(connectionString))
+            ConnectionFactory connectionFactory = new ConnectionFactory
             {
-                connectionFactory.Uri = new Uri(connectionString);
-            }
-            else
-            {
-                if (!string.IsNullOrEmpty(hostName))
-                {
-                    connectionFactory.HostName = hostName;
-                }
-
-                if (!string.IsNullOrEmpty(userName))
-                {
-                    connectionFactory.UserName = userName;
-                }
-
-                if (!string.IsNullOrEmpty(password))
-                {
-                    connectionFactory.Password = password;
-                }
-
-                if (port != 0)
-                {
-                    connectionFactory.Port = port;
-                }
-            }
+                Uri = new Uri(connectionString),
+                DispatchConsumersAsync = true,
+            };
 
             return connectionFactory;
         }

--- a/src/Trigger/QueueConfiguration.cs
+++ b/src/Trigger/QueueConfiguration.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
+{
+    public class QueueConfiguration
+    {
+        public string Name { get; set; }
+
+        public bool Durable { get; set; }
+
+        public bool Exclusive { get; set; }
+
+        public bool AutoDelete { get; set; }
+
+        public IDictionary<string, object> Arguments { get; set; }
+
+        public string DeadLetterExchangeName { get; set; }
+    }
+}

--- a/src/Trigger/RabbitMQTriggerBinding.cs
+++ b/src/Trigger/RabbitMQTriggerBinding.cs
@@ -17,14 +17,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
     internal class RabbitMQTriggerBinding : ITriggerBinding
     {
         private readonly IRabbitMQService _service;
-        private readonly string _queueName;
+        private readonly TriggerConfiguration _triggerOptions;
         private readonly string _hostName;
         private readonly ILogger _logger;
 
-        public RabbitMQTriggerBinding(IRabbitMQService service, string hostname, string queueName, ILogger logger)
+        public RabbitMQTriggerBinding(IRabbitMQService service, string hostname, TriggerConfiguration triggerOptions, ILogger logger)
         {
             _service = service;
-            _queueName = queueName;
+            _triggerOptions = triggerOptions;
             _hostName = hostname;
             _logger = logger;
             BindingDataContract = CreateBindingDataContract();
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 throw new ArgumentNullException("context");
             }
 
-            return Task.FromResult<IListener>(new RabbitMQListener(context.Executor, _service, _queueName, _logger, context.Descriptor));
+            return Task.FromResult<IListener>(new RabbitMQListener(context.Executor, _service, _triggerOptions, _logger, context.Descriptor));
         }
 
         public ParameterDescriptor ToParameterDescriptor()
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             return new RabbitMQTriggerParameterDescriptor
             {
                 Hostname = _hostName,
-                QueueName = _queueName,
+                QueueName = _triggerOptions.Queue.Name,
             };
         }
 

--- a/src/Trigger/TriggerConfiguration.cs
+++ b/src/Trigger/TriggerConfiguration.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
+{
+    public class TriggerConfiguration
+    {
+        private ushort _prefetchCount;
+
+        public ushort PrefetchCount
+        {
+            get => _prefetchCount;
+            set
+            {
+                if (value <= 0)
+                {
+                    throw new ArgumentOutOfRangeException($"{nameof(PrefetchCount)} value must be greater than 0");
+                }
+
+                _prefetchCount = value;
+            }
+        }
+
+        public QueueConfiguration Queue { get; set; }
+    }
+}

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQClientBuilderTests.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQClientBuilderTests.cs
@@ -26,7 +26,7 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
             var config = new RabbitMQExtensionConfigProvider(options, mockNameResolver.Object, mockServiceFactory.Object, loggerFactory, _emptyConfig);
             var mockService = new Mock<IRabbitMQService>();
 
-            mockServiceFactory.Setup(m => m.CreateService(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>())).Returns(mockService.Object);
+            mockServiceFactory.Setup(m => m.CreateService(It.IsAny<string>())).Returns(mockService.Object);
 
             RabbitMQAttribute attr = new RabbitMQAttribute
             {
@@ -36,12 +36,13 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
                 Password = "guest",
                 Port = 5672
             };
+            var expectedString = $"amqp://{attr.UserName}:{attr.Password}@{attr.HostName}:{attr.Port}";
 
             RabbitMQClientBuilder clientBuilder = new RabbitMQClientBuilder(config, options);
 
             var model = clientBuilder.Convert(attr);
 
-            mockServiceFactory.Verify(m => m.CreateService(It.IsAny<string>(), Constants.LocalHost, "guest", "guest", 5672), Times.Exactly(1));
+            mockServiceFactory.Verify(m => m.CreateService(expectedString), Times.Exactly(1));
         }
     }
 }

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQServiceTests.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQServiceTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.Azure.WebJobs.Extensions.RabbitMQ;
-using Moq;
 using RabbitMQ.Client;
 using Xunit;
 
@@ -12,13 +11,12 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
     public class RabbitMQServiceTests
     {
         [Theory]
-        [InlineData("", "localhost", "guest", "guest", 5672, "", "localhost", "guest", "guest", 5672)]
-        [InlineData("amqp://testUserName:testPassword@11.111.111.11:5672", null, null, null, null, "amqp://testUserName:testPassword@11.111.111.11:5672", "11.111.111.11", "testUserName", "testPassword", 5672)]
-        [InlineData("", "localhost", null, null, 0, "", "localhost", "guest", "guest", -1)] // Should fill in "guest", "guest", 5672
-        public void Handles_Connection_Attributes_And_Options(string connectionString, string hostName, string userName, string password, int port,
+        [InlineData("amqp://guest:guest@localhost:5672", "amqp://guest:guest@localhost:5672", "localhost", "guest", "guest", 5672)]
+        [InlineData("amqp://testUserName:testPassword@11.111.111.11:5672", "amqp://testUserName:testPassword@11.111.111.11:5672", "11.111.111.11", "testUserName", "testPassword", 5672)]
+        public void Handles_Connection_Attributes_And_Options(string connectionString,
             string expectedConnectionString, string expectedHostName, string expectedUserName, string expectedPassword, int expectedPort)
         {
-            ConnectionFactory factory = RabbitMQService.GetConnectionFactory(connectionString, hostName, userName, password, port);
+            ConnectionFactory factory = RabbitMQService.GetConnectionFactory(connectionString);
 
             if (String.IsNullOrEmpty(connectionString))
             {

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/WebJobs.Extensions.RabbitMQ.Tests.csproj
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/WebJobs.Extensions.RabbitMQ.Tests.csproj
@@ -1,13 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.5" />
+    <PackageReference Include="AutoFixture" Version="4.11.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.6" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.10" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />


### PR DESCRIPTION
Que configuration extended. As it would be nice to provide lots of configuration knobs it's expected that it will be done through host.json file. 
In scope of this PR Trigger aka consumer queue configuration added. Model's layer intorduced, it's meant to be closer to service layer and don't mess with Options and Attributes.

From my perspective configuration for trigger and binding should be split as the have only few things in common. Configuration for binding was not implemented, as I don't know what's the maintainer's view on that.

Asyncronous consuming implemented properly using AsyncEventingBasicConsumer.