### PR TITLE
Add a way to configure how queues are declared to handle complex scen…

### DIFF
--- a/src/Config/DefaultRabbitMQServiceFactory.cs
+++ b/src/Config/DefaultRabbitMQServiceFactory.cs
@@ -1,13 +1,24 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Trigger;
+
 namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     internal class DefaultRabbitMQServiceFactory : IRabbitMQServiceFactory
     {
-        public IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port, string deadLetterExchangeName)
+        public IRabbitMQService CreateService(
+            string connectionString,
+            string hostName,
+            string queueName,
+            string userName,
+            string password,
+            int port,
+            string deadLetterExchangeName,
+            IRabbitMQQueueDefinitionFactory queueDefinitionFactory
+        )
         {
-            return new RabbitMQService(connectionString, hostName, queueName, userName, password, port, deadLetterExchangeName);
+            return new RabbitMQService(connectionString, hostName, queueName, userName, password, port, deadLetterExchangeName, queueDefinitionFactory);
         }
 
         public IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port)

--- a/src/Config/IRabbitMQServiceFactory.cs
+++ b/src/Config/IRabbitMQServiceFactory.cs
@@ -1,11 +1,23 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Trigger;
+
 namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     public interface IRabbitMQServiceFactory
     {
-        IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port, string deadLetterExchangeName);
+        IRabbitMQService CreateService(
+            string connectionString,
+            string hostName,
+            string queueName,
+            string userName,
+            string password,
+            int port,
+            string deadLetterExchangeName,
+            IRabbitMQQueueDefinitionFactory queueDefinitionFactory
+        );
+
         IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port);
     }
 }

--- a/src/RabbitMQAttribute.cs
+++ b/src/RabbitMQAttribute.cs
@@ -43,5 +43,7 @@ namespace Microsoft.Azure.WebJobs
 
         [AutoResolve]
         public string DeadLetterExchangeName { get; set; }
+
+        public Type QueueDefinitionFactoryType { get; set; }
     }
 }

--- a/src/Trigger/IRabbitMQQueueDefinitionFactory.cs
+++ b/src/Trigger/IRabbitMQQueueDefinitionFactory.cs
@@ -1,0 +1,12 @@
+#nullable enable
+namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Trigger
+{
+    public interface IRabbitMQQueueDefinitionFactory
+    {
+        public RabbitMQQueueDefinition BuildDefinition(string queueName);
+
+        public string? GetDeadLetterQueueName(string queueName);
+
+        public RabbitMQQueueDefinition BuildDeadLetterQueueDefinition(string deadLetterQueueName);
+    }
+}

--- a/src/Trigger/RabbitMQQueueDefinition.cs
+++ b/src/Trigger/RabbitMQQueueDefinition.cs
@@ -1,0 +1,16 @@
+#nullable enable
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Trigger
+{
+    public class RabbitMQQueueDefinition
+    {
+        public bool Durable { get; set; }
+
+        public bool AutoDelete { get; set; }
+
+        public bool Exclusive { get; set; }
+
+        public IDictionary<string, object>? Arguments { get; set; }
+    }
+}

--- a/src/Trigger/RabbitMQQueueDefinitionBuilder.cs
+++ b/src/Trigger/RabbitMQQueueDefinitionBuilder.cs
@@ -1,0 +1,284 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using RabbitMQ.Client;
+
+namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Trigger
+{
+    public enum QueueType
+    {
+        Classic,
+        Quorum,
+    }
+
+    public enum OverflowBehaviour
+    {
+        DropHead,
+        RejectPublish,
+        RejectPublishDlx,
+    }
+
+    public class RabbitMQQueueDefinitionBuilder
+    {
+        private readonly QueueType _queueType;
+        private bool _durable;
+        private bool _autoDelete;
+        private bool _exclusive;
+        private int? _queueExpiresMilliseconds;
+        private int? _messageTtlMilliseconds;
+        private int? _maxLength;
+        private int? _maxLengthByte;
+        private OverflowBehaviour? _overflowBehaviour;
+        private string? _deadLetterExchangeName;
+        private string? _deadLetterRoutingKey;
+        private bool? _singleActiveConsumer;
+        private byte? _maxPriorityLevel;
+        private bool? _lazyMode;
+        private string? _masterLocator;
+
+        public RabbitMQQueueDefinitionBuilder(QueueType queueType)
+        {
+            _queueType = queueType;
+        }
+
+        /// <summary>
+        /// Define the queue to be Durable
+        /// Durable queues will be recovered on node boot, including messages in them published as persistent.
+        /// Messages published as transient will be discarded during recovery, even if they were stored in durable queues
+        /// <see href="https://www.rabbitmq.com/queues.html"/>
+        /// </summary>
+        public RabbitMQQueueDefinitionBuilder Durable()
+        {
+            _durable = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Define the queue to be Transient
+        /// Transient queues will be deleted on node boot. They therefore will not survive a node restart, by design.
+        /// Messages in transient queues will also be discarded.
+        /// <see href="https://www.rabbitmq.com/queues.html"/>
+        /// </summary>
+        public RabbitMQQueueDefinitionBuilder Transient()
+        {
+            _durable = false;
+            return this;
+        }
+
+        /// <summary>
+        /// An auto-delete queue will be deleted when its last consumer is cancelled (by calling .Cancel) or gone
+        /// (closed channel or connection, or lost TCP connection with the server).
+        /// <see href="https://www.rabbitmq.com/queues.html"/>
+        /// </summary>
+        public RabbitMQQueueDefinitionBuilder AutoDelete(bool autoDelete = true)
+        {
+            _autoDelete = autoDelete;
+            return this;
+        }
+
+        /// <summary>
+        /// An exclusive queue can only be used (consumed from, purged, deleted, etc) by its declaring connection.
+        /// <see href="https://www.rabbitmq.com/queues.html"/>
+        /// </summary>
+        public RabbitMQQueueDefinitionBuilder Exclusive(bool exclusive = true)
+        {
+            _exclusive = exclusive;
+            return this;
+        }
+
+        /// <summary>
+        /// How long a queue can be unused for before it is automatically deleted (milliseconds)
+        /// </summary>
+        public RabbitMQQueueDefinitionBuilder WithExpire(int expiresMilliseconds)
+        {
+            _queueExpiresMilliseconds = expiresMilliseconds;
+            return this;
+        }
+
+        /// <summary>
+        /// How long a message published to a queue can live before it is discarded (milliseconds).
+        /// </summary>
+        public RabbitMQQueueDefinitionBuilder WithMessageTtl(int ttlMilliseconds)
+        {
+            _messageTtlMilliseconds = ttlMilliseconds;
+            return this;
+        }
+
+        /// <summary>
+        /// How long a message published to a queue can live before it is discarded (milliseconds).
+        /// </summary>
+        public RabbitMQQueueDefinitionBuilder WithMessageTtl(TimeSpan ttl)
+        {
+            _messageTtlMilliseconds = (int)ttl.TotalMilliseconds;
+            return this;
+        }
+
+        /// <summary>
+        /// How many (ready) messages a queue can contain before it starts to drop them from its head.
+        /// </summary>
+        public RabbitMQQueueDefinitionBuilder WithMaxLength(int maxLength)
+        {
+            _maxLength = maxLength;
+            return this;
+        }
+
+        /// <summary>
+        /// Total body size for ready messages a queue can contain before it starts to drop them from its head.
+        /// </summary>
+        public RabbitMQQueueDefinitionBuilder WithMaxLengthByte(int maxLengthByte)
+        {
+            _maxLengthByte = maxLengthByte;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the queue overflow behaviour. This determines what happens to messages when the maximum length of a
+        /// queue is reached. Valid values are drop-head, reject-publish or reject-publish-dlx. The quorum queue type only supports drop-head.
+        /// </summary>
+        public RabbitMQQueueDefinitionBuilder WithOverflowBehaviour(OverflowBehaviour overflowBehaviour)
+        {
+            if (_queueType == QueueType.Quorum && overflowBehaviour != OverflowBehaviour.DropHead)
+            {
+                throw new ArgumentException("The quorum queue type only supports drop-head.", nameof(overflowBehaviour));
+            }
+
+            _overflowBehaviour = overflowBehaviour;
+            return this;
+        }
+
+        /// <summary>
+        /// Optional name of an exchange to which messages will be republished if they are rejected or expire.
+        /// </summary>
+        public RabbitMQQueueDefinitionBuilder WithDeadLetterExchange(string exchangeName)
+        {
+            _deadLetterExchangeName = exchangeName;
+            return this;
+        }
+
+        /// <summary>
+        /// Optional replacement routing key to use when a message is dead-lettered.
+        /// If this is not set, the message's original routing key will be used.
+        /// </summary>
+        public RabbitMQQueueDefinitionBuilder WithDeadLetterRoutingKey(string routingKey)
+        {
+            _deadLetterRoutingKey = routingKey;
+            return this;
+        }
+
+        /// <summary>
+        /// If set, makes sure only one consumer at a time consumes from the queue and fails over to another registered
+        /// consumer in case the active one is cancelled or dies.
+        /// </summary>
+        public RabbitMQQueueDefinitionBuilder WithSingleActiveConsumer()
+        {
+            _singleActiveConsumer = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Maximum number of priority levels for the queue to support;
+        /// if not set, the queue will not support message priorities.
+        /// </summary>
+        public RabbitMQQueueDefinitionBuilder WithMaximumNumberOfPriorityLevel(byte maxPriorityLevel)
+        {
+            _maxPriorityLevel = maxPriorityLevel;
+            return this;
+        }
+
+        /// <summary>
+        /// Set the queue into lazy mode, keeping as many messages as possible on disk to reduce RAM usage;
+        /// if not set, the queue will keep an in-memory cache to deliver messages as fast as possible.
+        /// </summary>
+        public RabbitMQQueueDefinitionBuilder WithLazyMode()
+        {
+            _lazyMode = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Set the queue into master location mode, determining the rule by which the queue master is located when
+        /// declared on a cluster of nodes.
+        /// </summary>
+        public RabbitMQQueueDefinitionBuilder WithMasterLocator(string locator)
+        {
+            _masterLocator = locator;
+            return this;
+        }
+
+        public RabbitMQQueueDefinition Build()
+        {
+            IDictionary<string, object> arguments = new Dictionary<string, object>();
+            if (_queueExpiresMilliseconds != null)
+            {
+                arguments[Headers.XExpires] = _queueExpiresMilliseconds;
+            }
+
+            if (_messageTtlMilliseconds != null)
+            {
+                arguments[Headers.XMessageTTL] = _messageTtlMilliseconds;
+            }
+
+            if (_maxLength != null)
+            {
+                arguments[Headers.XMaxLength] = _maxLength;
+            }
+
+            if (_maxLengthByte != null)
+            {
+                arguments[Headers.XMaxLengthInBytes] = _maxLengthByte;
+            }
+
+            if (_overflowBehaviour != null)
+            {
+                // TODO: After client version 6+: Headers.XOverflow
+                arguments["x-overflow"] = _overflowBehaviour.Value switch
+                {
+                    OverflowBehaviour.DropHead => "drop-head",
+                    OverflowBehaviour.RejectPublish => "reject-publish",
+                    OverflowBehaviour.RejectPublishDlx => "reject-publish-dlx",
+                    _ => throw new ArgumentOutOfRangeException()
+                };
+            }
+
+            if (_deadLetterExchangeName != null)
+            {
+                arguments[Headers.XDeadLetterExchange] = _deadLetterExchangeName;
+            }
+
+            if (_deadLetterRoutingKey != null)
+            {
+                arguments[Headers.XDeadLetterRoutingKey] = _deadLetterRoutingKey;
+            }
+
+            // TODO: After client version 6+: Headers.XSingleActiveConsumer
+            if (_singleActiveConsumer != null)
+            {
+                arguments["x-single-active-consumer"] = _singleActiveConsumer;
+            }
+
+            if (_maxPriorityLevel != null)
+            {
+                arguments[Headers.XMaxPriority] = _maxPriorityLevel;
+            }
+
+            // TODO: After client version 6+: Headers.XQueueMode
+            if (_lazyMode != null)
+            {
+                arguments["x-queue-mode"] = _lazyMode.Value ? "lazy" : "default";
+            }
+
+            if (_masterLocator != null)
+            {
+                arguments["x-queue-master-locator"] = _masterLocator;
+            }
+
+            return new RabbitMQQueueDefinition
+            {
+                Durable = _durable,
+                AutoDelete = _autoDelete,
+                Exclusive = _exclusive,
+                Arguments = arguments.Count == 0 ? null : arguments,
+            };
+        }
+    }
+}

--- a/src/Trigger/RabbitMQTriggerAttribute.cs
+++ b/src/Trigger/RabbitMQTriggerAttribute.cs
@@ -40,5 +40,7 @@ namespace Microsoft.Azure.WebJobs
         public int Port { get; set; }
 
         public string DeadLetterExchangeName { get; set; }
+
+        public Type QueueDefinitionFactoryType { get; set; }
     }
 }

--- a/test/WebJobs.Extensions.RabbitMQ.Samples/Program.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Samples/Program.cs
@@ -18,7 +18,8 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
             // be indexed by the JobHost.
             // To run some of the other samples included, add their types to this list
             var typeLocator = new SamplesTypeLocator(
-                typeof(RabbitMQSamples));
+                typeof(RabbitMQSamples),
+                typeof(RabbitMQSamplesChainedErrorQueues));
 
             var builder = new HostBuilder()
                .UseEnvironment("Development")

--- a/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamplesChainedErrorQueues.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamplesChainedErrorQueues.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Trigger;
+using Microsoft.Extensions.Logging;
+
+namespace WebJobs.Extensions.RabbitMQ.Samples
+{
+    public static class RabbitMQSamplesChainedErrorQueues
+    {
+        private const string DefaultExchangeName = "";
+
+        // This sample show how to listen to the message that failed to be processed and ends up into Dead Letter Queue
+        // after they have been retried
+        public static void RabbitMQTrigger_ChainedQueue1(
+            [RabbitMQTrigger(
+                "chained-test-queue",
+                ConnectionStringSetting = "rabbitMQ",
+                QueueDefinitionFactoryType = typeof(ProcessorQueueDefinitionFactory))
+            ]
+            string message,
+            ILogger logger
+        )
+        {
+            logger.LogInformation($"Received message in main queue: {message}");
+            throw new Exception("An error occured");
+        }
+
+        public static void RabbitMQTrigger_ChainedQueue2(
+            [RabbitMQTrigger(
+                "chained-test-queue-failed",
+                ConnectionStringSetting = "rabbitMQ",
+                QueueDefinitionFactoryType = typeof(FailedQueueDefinitionFactory))
+            ]
+            string message,
+            ILogger logger
+        )
+        {
+            logger.LogWarning($"An error occured while trying to process a message: {message}, let's handle error here (put something in error state for example)");
+            throw new Exception("An error occured");
+        }
+
+        public class ProcessorQueueDefinitionFactory : IRabbitMQQueueDefinitionFactory
+        {
+            public RabbitMQQueueDefinition BuildDefinition(string queueName)
+            {
+                return new RabbitMQQueueDefinitionBuilder(QueueType.Classic)
+                    .Durable()
+                    .WithDeadLetterExchange(DefaultExchangeName)
+                    .WithDeadLetterRoutingKey(this.GetDeadLetterQueueName(queueName))
+                    .Build();
+            }
+
+            public string GetDeadLetterQueueName(string queueName)
+            {
+                return queueName + "-failed";
+            }
+
+            public RabbitMQQueueDefinition BuildDeadLetterQueueDefinition(string deadLetterQueueName)
+            {
+                return new RabbitMQQueueDefinitionBuilder(QueueType.Classic)
+                    .Durable()
+                    .WithDeadLetterExchange(DefaultExchangeName)
+                    .WithDeadLetterRoutingKey(deadLetterQueueName.Substring(0, deadLetterQueueName.LastIndexOf('-')) + "-error")
+                    .Build();
+            }
+        }
+
+        public class FailedQueueDefinitionFactory : IRabbitMQQueueDefinitionFactory
+        {
+            public RabbitMQQueueDefinition BuildDefinition(string queueName)
+            {
+                return new RabbitMQQueueDefinitionBuilder(QueueType.Classic)
+                    .Durable()
+                    .WithDeadLetterExchange(DefaultExchangeName)
+                    .WithDeadLetterRoutingKey(this.GetDeadLetterQueueName(queueName))
+                    .Build();
+            }
+
+            public string GetDeadLetterQueueName(string queueName)
+            {
+                return queueName.Substring(0, queueName.LastIndexOf('-')) + "-error";
+            }
+
+            public RabbitMQQueueDefinition BuildDeadLetterQueueDefinition(string deadLetterQueueName)
+            {
+                return new RabbitMQQueueDefinitionBuilder(QueueType.Classic)
+                    .Durable()
+                    .WithMessageTtl(TimeSpan.FromSeconds(60))
+                    .Build();
+            }
+        }
+    }
+}


### PR DESCRIPTION
…ario.

It's now possible to pass an implementation of `IRabbitMQQueueDefinitionFactory`
to a trigger so when the queue is declared, it will use the definition returned
by the methods.

This allow to configure Durable Queue (fixes: #68)
This may help with #76 since it allow to fully configure queue

This allow scenario like in the new Sample: where we may want to have 3 queue
chained together to handle error nicely, when the first queue fail to process
a message, it goes to the second queue, this allow to handle error after all
retry. And if this failed again, it can go to another queue that may be handle
manually and that will contains unexpetected errors.


Queue => Queue-Failed => Queue-Error

Also, I would like to rework `RabbitMQService` to move the logic of how the queue is created somewhere else so I can write unit tests. If you have any indication how this should be done, if you have any preference ?