### PR TITLE
Add new parameter to specify the vhost to use on RabbitMQ server.

### DIFF
--- a/binding-library/java/release_notes.md
+++ b/binding-library/java/release_notes.md
@@ -1,1 +1,3 @@
 ### Release notes
+
+- Add a new `VirtualHost` parameter to `RabbitMQTrigger`, `RabbitMQOutput` to allow to choose which [Virtual Hosts](https://www.rabbitmq.com/vhosts.html) to use when using host/user/password authentication method.

--- a/binding-library/java/src/main/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQOutput.java
+++ b/binding-library/java/src/main/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQOutput.java
@@ -76,6 +76,13 @@ public @interface RabbitMQOutput {
     String password() default "";
 
     /**
+     * The VirtualHost used on the rabbitMQ Server.
+     * @see <a href="https://www.rabbitmq.com/vhosts.html">Virtual Hosts</a>
+     * @return The VirtualHost used on the rabbitMQ Server.
+     */
+    String virtualHost() default "";
+
+    /**
      * The port to attach.
      * @return The port to attach.
      */

--- a/binding-library/java/src/main/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQTrigger.java
+++ b/binding-library/java/src/main/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQTrigger.java
@@ -72,6 +72,13 @@ public @interface RabbitMQTrigger {
     String passwordSetting() default "";
 
     /**
+     * The VirtualHost used on the rabbitMQ Server.
+     * @see <a href="https://www.rabbitmq.com/vhosts.html">Virtual Hosts</a>
+     * @return The VirtualHost used on the rabbitMQ Server.
+     */
+    String virtualHostSetting() default "";
+
+    /**
      * The port to attach.
      * @return The port to attach.
      */

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,1 +1,3 @@
 ### Release notes
+
+- Add a new `VirtualHost` parameter to `[RabbitMQTrigger]`, `[RabbitMQ]` and `RabbitMQOptions` to allow to choose which [Virtual Hosts](https://www.rabbitmq.com/vhosts.html) to use when using host/user/password authentication method.

--- a/src/Bindings/RabbitMQClientBuilder.cs
+++ b/src/Bindings/RabbitMQClientBuilder.cs
@@ -30,8 +30,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             string resolvedUserName = Utility.FirstOrDefault(attribute.UserName, _options.Value.UserName);
             string resolvedPassword = Utility.FirstOrDefault(attribute.Password, _options.Value.Password);
             int resolvedPort = Utility.FirstOrDefault(attribute.Port, _options.Value.Port);
+            string resolvedVirtualHost = Utility.FirstOrDefault(attribute.VirtualHost, _options.Value.VirtualHost);
 
-            IRabbitMQService service = _configProvider.GetService(resolvedConnectionString, resolvedHostName, resolvedUserName, resolvedPassword, resolvedPort);
+            IRabbitMQService service = _configProvider.GetService(resolvedConnectionString, resolvedHostName, resolvedUserName, resolvedPassword, resolvedPort, resolvedVirtualHost);
 
             return service.Model;
         }

--- a/src/Config/DefaultRabbitMQServiceFactory.cs
+++ b/src/Config/DefaultRabbitMQServiceFactory.cs
@@ -5,14 +5,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     internal class DefaultRabbitMQServiceFactory : IRabbitMQServiceFactory
     {
-        public IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port)
+        public IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port, string virtualHost)
         {
-            return new RabbitMQService(connectionString, hostName, queueName, userName, password, port);
+            return new RabbitMQService(connectionString, hostName, queueName, userName, password, port, virtualHost);
         }
 
-        public IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port)
+        public IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port, string virtualHost)
         {
-            return new RabbitMQService(connectionString, hostName, userName, password, port);
+            return new RabbitMQService(connectionString, hostName, userName, password, port, virtualHost);
         }
     }
 }

--- a/src/Config/IRabbitMQServiceFactory.cs
+++ b/src/Config/IRabbitMQServiceFactory.cs
@@ -5,8 +5,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     public interface IRabbitMQServiceFactory
     {
-        IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port);
+        IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port, string virtualHost);
 
-        IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port);
+        IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port, string virtualHost);
     }
 }

--- a/src/Config/RabbitMQExtensionConfigProvider.cs
+++ b/src/Config/RabbitMQExtensionConfigProvider.cs
@@ -83,6 +83,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             string userName = Utility.FirstOrDefault(attribute.UserName, _options.Value.UserName);
             string password = Utility.FirstOrDefault(attribute.Password, _options.Value.Password);
             int port = Utility.FirstOrDefault(attribute.Port, _options.Value.Port);
+            string virtualHost = Utility.FirstOrDefault(attribute.VirtualHost, _options.Value.VirtualHost);
 
             RabbitMQAttribute resolvedAttribute;
             IRabbitMQService service;
@@ -95,9 +96,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 UserName = userName,
                 Password = password,
                 Port = port,
+                VirtualHost = virtualHost,
             };
 
-            service = GetService(connectionString, hostName, queueName, userName, password, port);
+            service = GetService(connectionString, hostName, queueName, userName, password, port, virtualHost);
 
             return new RabbitMQContext
             {
@@ -106,15 +108,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             };
         }
 
-        internal IRabbitMQService GetService(string connectionString, string hostName, string queueName, string userName, string password, int port)
+        internal IRabbitMQService GetService(string connectionString, string hostName, string queueName, string userName, string password, int port, string virtualHost)
         {
-            return _rabbitMQServiceFactory.CreateService(connectionString, hostName, queueName, userName, password, port);
+            return _rabbitMQServiceFactory.CreateService(connectionString, hostName, queueName, userName, password, port, virtualHost);
         }
 
         // Overloaded method used only for getting the RabbitMQ client
-        internal IRabbitMQService GetService(string connectionString, string hostName, string userName, string password, int port)
+        internal IRabbitMQService GetService(string connectionString, string hostName, string userName, string password, int port, string virtualHost)
         {
-            return _rabbitMQServiceFactory.CreateService(connectionString, hostName, userName, password, port);
+            return _rabbitMQServiceFactory.CreateService(connectionString, hostName, userName, password, port, virtualHost);
         }
     }
 }

--- a/src/Config/RabbitMQOptions.cs
+++ b/src/Config/RabbitMQOptions.cs
@@ -38,6 +38,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         public string Password { get; set; }
 
         /// <summary>
+        /// Gets or sets the VirtualHost used on the RabbitMQ Server.
+        /// <see href="https://www.rabbitmq.com/vhosts.html" />
+        /// </summary>
+        public string VirtualHost { get; set; }
+
+        /// <summary>
         /// Gets or sets the ConnectionString used to authenticate with RabbitMQ.
         /// </summary>
         public string ConnectionString { get; set; }

--- a/src/RabbitMQAttribute.cs
+++ b/src/RabbitMQAttribute.cs
@@ -34,6 +34,14 @@ namespace Microsoft.Azure.WebJobs
         [AppSetting]
         public string Password { get; set; }
 
+        /// <summary>
+        /// Gets or sets the vhost to use when connecting to RabbitMQ using HostName / UserName / Password
+        /// Optional
+        /// <see href="https://www.rabbitmq.com/vhosts.html"/>
+        /// </summary>
+        [AppSetting]
+        public string VirtualHost { get; set; }
+
         // Optional
         public int Port { get; set; }
 

--- a/src/Services/RabbitMQService.cs
+++ b/src/Services/RabbitMQService.cs
@@ -16,23 +16,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         private readonly string _queueName;
         private readonly string _userName;
         private readonly string _password;
+        private readonly string _virtualHost;
         private readonly int _port;
 
-        public RabbitMQService(string connectionString, string hostName, string userName, string password, int port)
+        public RabbitMQService(string connectionString, string hostName, string userName, string password, int port, string virtualHost)
         {
             _connectionString = connectionString;
             _hostName = hostName;
             _userName = userName;
             _password = password;
             _port = port;
+            _virtualHost = virtualHost;
 
-            ConnectionFactory connectionFactory = GetConnectionFactory(_connectionString, _hostName, _userName, _password, _port);
+            ConnectionFactory connectionFactory = GetConnectionFactory(_connectionString, _hostName, _userName, _password, _port, _virtualHost);
 
             _model = connectionFactory.CreateConnection().CreateModel();
         }
 
-        public RabbitMQService(string connectionString, string hostName, string queueName, string userName, string password, int port)
-            : this(connectionString, hostName, userName, password, port)
+        public RabbitMQService(string connectionString, string hostName, string queueName, string userName, string password, int port, string virtualHost)
+            : this(connectionString, hostName, userName, password, port, virtualHost)
         {
             _rabbitMQModel = new RabbitMQModel(_model);
             _queueName = queueName ?? throw new ArgumentNullException(nameof(queueName));
@@ -47,7 +49,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
         public IBasicPublishBatch BasicPublishBatch => _batch;
 
-        internal static ConnectionFactory GetConnectionFactory(string connectionString, string hostName, string userName, string password, int port)
+        internal static ConnectionFactory GetConnectionFactory(string connectionString, string hostName, string userName, string password, int port, string virtualHost)
         {
             ConnectionFactory connectionFactory = new ConnectionFactory();
 
@@ -71,6 +73,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 if (!string.IsNullOrEmpty(password))
                 {
                     connectionFactory.Password = password;
+                }
+
+                if (!string.IsNullOrEmpty(virtualHost))
+                {
+                    connectionFactory.VirtualHost = virtualHost;
                 }
 
                 if (port != 0)

--- a/src/Trigger/RabbitMQTriggerAttribute.cs
+++ b/src/Trigger/RabbitMQTriggerAttribute.cs
@@ -36,6 +36,8 @@ namespace Microsoft.Azure.WebJobs
         [AppSetting]
         public string PasswordSetting { get; set; }
 
+        public string VirtualHost { get; set; }
+
         public int Port { get; set; }
     }
 }

--- a/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
+++ b/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
@@ -59,6 +59,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
             string password = Resolve(attribute.PasswordSetting);
 
+            string virtualHost = Resolve(attribute.VirtualHost);
+
             int port = attribute.Port;
 
             if (string.IsNullOrEmpty(connectionString) && !Utility.ValidateUserNamePassword(userName, password, hostName))
@@ -66,7 +68,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 throw new InvalidOperationException("RabbitMQ username and password required if not connecting to localhost");
             }
 
-            IRabbitMQService service = _provider.GetService(connectionString, hostName, queueName, userName, password, port);
+            IRabbitMQService service = _provider.GetService(connectionString, hostName, queueName, userName, password, port, virtualHost);
 
             return Task.FromResult<ITriggerBinding>(new RabbitMQTriggerBinding(service, hostName, queueName, _logger, parameter.ParameterType, _options.Value.PrefetchCount));
         }

--- a/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
@@ -138,6 +138,14 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
             logger.LogInformation($"RabbitMQ output binding function sent message: {outputMessage}");
         }
 
+        public static void RabbitMQTrigger_String_NoConnectionString_WithVirtualHost(
+            [RabbitMQTrigger(hostName: "%RabbitMQHostName%", userNameSetting: "%UserNameSetting%", passwordSetting: "%PasswordSetting%", port: 5672, queueName: "queue-in-vhost", VirtualHost = "azure-rabbitmq-vhost")] string message,
+            string consumerTag,
+            ILogger logger)
+        {
+            logger.LogInformation($"RabbitMQ queue trigger function processed message: {message} and consumer tag: {consumerTag}");
+        }
+
         public class TestClass
         {
             private readonly int _x;

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQClientBuilderTests.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQClientBuilderTests.cs
@@ -26,7 +26,7 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
             var config = new RabbitMQExtensionConfigProvider(options, mockNameResolver.Object, mockServiceFactory.Object, loggerFactory, _emptyConfig);
             var mockService = new Mock<IRabbitMQService>();
 
-            mockServiceFactory.Setup(m => m.CreateService(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>())).Returns(mockService.Object);
+            mockServiceFactory.Setup(m => m.CreateService(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>())).Returns(mockService.Object);
 
             RabbitMQAttribute attr = new RabbitMQAttribute
             {
@@ -34,14 +34,15 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
                 HostName = Constants.LocalHost,
                 UserName = "guest",
                 Password = "guest",
-                Port = 5672
+                Port = 5672,
+                VirtualHost = "some-vhost"
             };
 
             RabbitMQClientBuilder clientBuilder = new RabbitMQClientBuilder(config, options);
 
             var model = clientBuilder.Convert(attr);
 
-            mockServiceFactory.Verify(m => m.CreateService(It.IsAny<string>(), Constants.LocalHost, "guest", "guest", 5672), Times.Exactly(1));
+            mockServiceFactory.Verify(m => m.CreateService(It.IsAny<string>(), Constants.LocalHost, "guest", "guest", 5672, "some-vhost"), Times.Exactly(1));
         }
     }
 }

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQServiceTests.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQServiceTests.cs
@@ -11,13 +11,13 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
     public class RabbitMQServiceTests
     {
         [Theory]
-        [InlineData("", "localhost", "guest", "guest", 5672, "", "localhost", "guest", "guest", 5672)]
-        [InlineData("amqp://testUserName:testPassword@11.111.111.11:5672", null, null, null, null, "amqp://testUserName:testPassword@11.111.111.11:5672", "11.111.111.11", "testUserName", "testPassword", 5672)]
-        [InlineData("", "localhost", null, null, 0, "", "localhost", "guest", "guest", -1)] // Should fill in "guest", "guest", 5672
-        public void Handles_Connection_Attributes_And_Options(string connectionString, string hostName, string userName, string password, int port,
-            string expectedConnectionString, string expectedHostName, string expectedUserName, string expectedPassword, int expectedPort)
+        [InlineData("", "localhost", "guest", "guest", 5672, "some-vhost", "", "localhost", "guest", "guest", 5672, "some-vhost")]
+        [InlineData("amqp://testUserName:testPassword@11.111.111.11:5672/some-vhost", null, null, null, null, "some-vhost", "amqp://testUserName:testPassword@11.111.111.11:5672/some-vhost", "11.111.111.11", "testUserName", "testPassword", 5672, "some-vhost")]
+        [InlineData("", "localhost", null, null, 0, "some-vhost", "", "localhost", "guest", "guest", -1, "some-vhost")] // Should fill in "guest", "guest", 5672
+        public void Handles_Connection_Attributes_And_Options(string connectionString, string hostName, string userName, string password, int port, string virtualHost,
+            string expectedConnectionString, string expectedHostName, string expectedUserName, string expectedPassword, int expectedPort, string expectedVirtualHost)
         {
-            ConnectionFactory factory = RabbitMQService.GetConnectionFactory(connectionString, hostName, userName, password, port);
+            ConnectionFactory factory = RabbitMQService.GetConnectionFactory(connectionString, hostName, userName, password, port, virtualHost);
 
             if (String.IsNullOrEmpty(connectionString))
             {
@@ -26,6 +26,7 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
                 Assert.Equal(expectedUserName, factory.UserName);
                 Assert.Equal(expectedPassword, factory.Password);
                 Assert.Equal(expectedPort, factory.Port);
+                Assert.Equal(expectedVirtualHost, factory.VirtualHost);
             }
             else
             {
@@ -34,6 +35,7 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
                 Assert.Equal(expectedUserName, factory.UserName);
                 Assert.Equal(expectedPassword, factory.Password);
                 Assert.Equal(expectedPort, factory.Port);
+                Assert.Equal(expectedVirtualHost, factory.VirtualHost);
             }
         }
     }


### PR DESCRIPTION
See https://www.rabbitmq.com/vhosts.html for more details.
It was already possible to use this using the ConnectionString, this allow it
to be used when specifying host/user/password

Fixes: #81