### PR TITLE
[pack] Added build steps for mvn

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ jobs:
   condition: and(succeeded(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.InitializePipeline.outputs['Initialize.BuildArtifacts'], true)))
   variables:
     releaseVersionNumber: $[dependencies.InitializePipeline.outputs['Initialize.BuildNumber']]
-    mvnPackagePrefix: $[dependencies.InitializePipeline.outputs['Initialize.MvnPackagePrefix']]
+    mvnPrefix: $[dependencies.InitializePipeline.outputs['Initialize.MvnPackagePrefix']]
     buildCounter: $[counter(variables['releaseVersionNumber'], 1)]
   pool:
     vmImage: 'vs2017-win2016'
@@ -144,10 +144,10 @@ jobs:
     inputs:
       filePath: '$(Build.Repository.LocalPath)\build\mvnBuildAndPackage.ps1'
   - publish: $(Build.Repository.LocalPath)\packages\Microsoft.Azure.WebJobs.Extensions.RabbitMQ
-  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\${{ variables.mvnPackagePrefix }}.xml
-  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\${{ variables.mvnPackagePrefix }}.jar
-  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\${{ variables.mvnPackagePrefix }}-javadoc.jar
-  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\${{ variables.mvnPackagePrefix }}-sources.jar
+  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\${{ variables.mvnPrefix }}.xml
+  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\${{ variables.mvnPrefix }}.jar
+  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\${{ variables.mvnPrefix }}-javadoc.jar
+  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\${{ variables.mvnPrefix }}-sources.jar
 
 - job: RunTests
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -142,7 +142,7 @@ jobs:
     displayName: 'Mvn package'
     name: MvnBuildAndPackage
     inputs:
-      filePath: '$(Build.Repository.LocalPath)\build\mvnBuildAndPackage.ps1'
+      filePath: '$(Build.Repository.LocalPath)\build\mvnBuildAndPackage.ps1 -mvnPrefix ''$(mvnPrefix)'''
   - publish: $(Build.Repository.LocalPath)\packages\Microsoft.Azure.WebJobs.Extensions.RabbitMQ
   - publish: $(Build.Repository.LocalPath)\binding-library\java\target\${{ variables.mvnPrefix }}.xml
   - publish: $(Build.Repository.LocalPath)\binding-library\java\target\${{ variables.mvnPrefix }}.jar

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,9 +21,20 @@ jobs:
     inputs:
       filePath: '$(Build.Repository.LocalPath)\build\initialize-pipeline.ps1'
       arguments: '-versionPath ''$(Build.Repository.LocalPath)\src'''
+
+- job: MvnBuild
+  pool:
+    vmImage: 'vs2017-win2016'
+  steps:
+  - task: BatchScript@1
+    inputs:
+       filename: 'mvnBuild.bat'
+       workingFolder: '$(Build.Repository.LocalPath)\binding-library\java'
       
 - job: BuildArtifacts
-  dependsOn: InitializePipeline
+  dependsOn: 
+    - InitializePipeline
+    - MvnBuild
   condition: and(succeeded(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.InitializePipeline.outputs['Initialize.BuildArtifacts'], true)))
   variables:
     releaseVersionNumber: $[dependencies.InitializePipeline.outputs['Initialize.BuildNumber']]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -136,7 +136,16 @@ jobs:
     inputs:
       contents: '**\CodeSignSummary-*.md'
     condition: and(succeeded(), startsWith(variables['VersioningAndSigning.SignArtifacts'], 'true'))
+  - task: PowerShell@2
+    displayName: 'Mvn package'
+    name: MvnBuildAndPackage
+    inputs:
+      filePath: '$(Build.Repository.LocalPath)\build\mvnBuildAndPackage.ps1'
   - publish: $(Build.Repository.LocalPath)\packages\Microsoft.Azure.WebJobs.Extensions.RabbitMQ
+  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\$(outputXmlFileName).xml
+  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\$(outputXmlFileName).jar
+  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\$(outputXmlFileName)-javadoc.jar
+  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\$(outputXmlFileName)-sources.jar
 
 - job: RunTests
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -148,10 +148,7 @@ jobs:
       filePath: '$(Build.Repository.LocalPath)\build\mvnBuildAndPackage.ps1'
       arguments: '-mvnPrefix ''$(mvnPrefix)'''
   - publish: $(Build.Repository.LocalPath)\packages\Microsoft.Azure.WebJobs.Extensions.RabbitMQ
-  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\${{ variables.mvnPrefix }}.xml
-  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\${{ variables.mvnPrefix }}.jar
-  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\${{ variables.mvnPrefix }}-javadoc.jar
-  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\${{ variables.mvnPrefix }}-sources.jar
+  - publish: $(Build.Repository.LocalPath)\binding-library\java\ToBePublished
 
 - job: RunTests
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -148,7 +148,9 @@ jobs:
       filePath: '$(Build.Repository.LocalPath)\build\mvnBuildAndPackage.ps1'
       arguments: '-mvnPrefix ''$(mvnPrefix)'''
   - publish: $(Build.Repository.LocalPath)\packages\Microsoft.Azure.WebJobs.Extensions.RabbitMQ
+    artifact: Nuget
   - publish: $(Build.Repository.LocalPath)\binding-library\java\ToBePublished
+    artifact: Java
 
 - job: RunTests
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,8 +28,7 @@ jobs:
   steps:
   - task: BatchScript@1
     inputs:
-       filename: 'mvnBuild.bat'
-       workingFolder: '$(Build.Repository.LocalPath)\binding-library\java'
+       filename: '$(Build.Repository.LocalPath)\binding-library\java\mvnBuild.bat'
       
 - job: BuildArtifacts
   dependsOn: 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,6 +25,8 @@ jobs:
 - job: MvnBuild
   dependsOn: InitializePipeline
   condition: ne(dependencies.InitializePipeline.outputs['Initialize.BuildArtifacts'], true)
+  variables:
+    mvnPrefix: $[dependencies.InitializePipeline.outputs['Initialize.MvnPackagePrefix']]
   pool:
     vmImage: 'vs2017-win2016'
   steps:
@@ -33,6 +35,7 @@ jobs:
     name: MvnBuild
     inputs:
       filePath: '$(Build.Repository.LocalPath)\build\MvnBuildAndPackage.ps1'
+      arguments: '-mvnPrefix ''$(mvnPrefix)'''
       
 - job: BuildArtifacts
   dependsOn: 
@@ -142,7 +145,8 @@ jobs:
     displayName: 'Mvn package'
     name: MvnBuildAndPackage
     inputs:
-      filePath: '$(Build.Repository.LocalPath)\build\mvnBuildAndPackage.ps1 -mvnPrefix ''$(mvnPrefix)'''
+      filePath: '$(Build.Repository.LocalPath)\build\mvnBuildAndPackage.ps1'
+      arguments: '-mvnPrefix ''$(mvnPrefix)'''
   - publish: $(Build.Repository.LocalPath)\packages\Microsoft.Azure.WebJobs.Extensions.RabbitMQ
   - publish: $(Build.Repository.LocalPath)\binding-library\java\target\${{ variables.mvnPrefix }}.xml
   - publish: $(Build.Repository.LocalPath)\binding-library\java\target\${{ variables.mvnPrefix }}.jar

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -148,9 +148,9 @@ jobs:
       filePath: '$(Build.Repository.LocalPath)\build\mvnBuildAndPackage.ps1'
       arguments: '-mvnPrefix ''$(mvnPrefix)'''
   - publish: $(Build.Repository.LocalPath)\packages\Microsoft.Azure.WebJobs.Extensions.RabbitMQ
-    artifact: Microsoft.Azure.WebJobs.Extensions.RabbitMQ.${{ variables.releaseVersionNumber }}
+    artifact: Microsoft.Azure.WebJobs.Extensions.RabbitMQ.$(releaseVersionNumber)
   - publish: $(Build.Repository.LocalPath)\binding-library\java\ToBePublished
-    artifact: ${{ variables.mvnPrefix }}
+    artifact: $(mvnPrefix)
 
 - job: RunTests
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
   dependsOn: 
     - InitializePipeline
     - MvnBuild
-  condition: and(succeeded(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.InitializePipeline.outputs['Initialize.BuildArtifacts'], true)))
+  condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.InitializePipeline.outputs['Initialize.BuildArtifacts'], true))
   variables:
     releaseVersionNumber: $[dependencies.InitializePipeline.outputs['Initialize.BuildNumber']]
     mvnPackagePrefix: $[dependencies.InitializePipeline.outputs['Initialize.MvnPackagePrefix']]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,8 +37,7 @@ jobs:
 - job: BuildArtifacts
   dependsOn: 
     - InitializePipeline
-    - MvnBuild
-  condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.InitializePipeline.outputs['Initialize.BuildArtifacts'], true))
+  condition: and(succeeded(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.InitializePipeline.outputs['Initialize.BuildArtifacts'], true)))
   variables:
     releaseVersionNumber: $[dependencies.InitializePipeline.outputs['Initialize.BuildNumber']]
     mvnPackagePrefix: $[dependencies.InitializePipeline.outputs['Initialize.MvnPackagePrefix']]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,9 +20,11 @@ jobs:
     name: Initialize
     inputs:
       filePath: '$(Build.Repository.LocalPath)\build\initialize-pipeline.ps1'
-      arguments: '-versionPath ''$(Build.Repository.LocalPath)\src'''
+      arguments: '-versionPath ''$(Build.Repository.LocalPath)\src'' -javaPath ''$(Build.Repository.LocalPath)\binding-library\java'''
 
 - job: MvnBuild
+  dependsOn: InitializePipeline
+  condition: ne(dependencies.InitializePipeline.outputs['Initialize.BuildArtifacts'], true)
   pool:
     vmImage: 'vs2017-win2016'
   steps:
@@ -30,7 +32,7 @@ jobs:
     displayName: 'Mvn build'
     name: MvnBuild
     inputs:
-      filePath: '$(Build.Repository.LocalPath)\build\mvnBuild.ps1'
+      filePath: '$(Build.Repository.LocalPath)\build\MvnBuildAndPackage.ps1'
       
 - job: BuildArtifacts
   dependsOn: 
@@ -39,6 +41,7 @@ jobs:
   condition: and(succeeded(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.InitializePipeline.outputs['Initialize.BuildArtifacts'], true)))
   variables:
     releaseVersionNumber: $[dependencies.InitializePipeline.outputs['Initialize.BuildNumber']]
+    mvnPackagePrefix: $[dependencies.InitializePipeline.outputs['Initialize.MvnPackagePrefix']]
     buildCounter: $[counter(variables['releaseVersionNumber'], 1)]
   pool:
     vmImage: 'vs2017-win2016'
@@ -142,10 +145,10 @@ jobs:
     inputs:
       filePath: '$(Build.Repository.LocalPath)\build\mvnBuildAndPackage.ps1'
   - publish: $(Build.Repository.LocalPath)\packages\Microsoft.Azure.WebJobs.Extensions.RabbitMQ
-  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\$(MvnPackagePrefix).xml
-  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\$(MvnPackagePrefix).jar
-  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\$(MvnPackagePrefix)-javadoc.jar
-  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\$(MvnPackagePrefix)-sources.jar
+  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\${{ variables.mvnPackagePrefix }}.xml
+  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\${{ variables.mvnPackagePrefix }}.jar
+  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\${{ variables.mvnPackagePrefix }}-javadoc.jar
+  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\${{ variables.mvnPackagePrefix }}-sources.jar
 
 - job: RunTests
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -142,10 +142,10 @@ jobs:
     inputs:
       filePath: '$(Build.Repository.LocalPath)\build\mvnBuildAndPackage.ps1'
   - publish: $(Build.Repository.LocalPath)\packages\Microsoft.Azure.WebJobs.Extensions.RabbitMQ
-  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\$(outputXmlFileName).xml
-  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\$(outputXmlFileName).jar
-  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\$(outputXmlFileName)-javadoc.jar
-  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\$(outputXmlFileName)-sources.jar
+  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\$(MvnPackagePrefix).xml
+  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\$(MvnPackagePrefix).jar
+  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\$(MvnPackagePrefix)-javadoc.jar
+  - publish: $(Build.Repository.LocalPath)\binding-library\java\target\$(MvnPackagePrefix)-sources.jar
 
 - job: RunTests
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,9 +26,11 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
   steps:
-  - task: BatchScript@1
+  - task: PowerShell@2
+    displayName: 'Mvn build'
+    name: MvnBuild
     inputs:
-       filename: '$(Build.Repository.LocalPath)\binding-library\java\mvnBuild.bat'
+      filePath: '$(Build.Repository.LocalPath)\build\mvnBuild.ps1'
       
 - job: BuildArtifacts
   dependsOn: 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -148,9 +148,9 @@ jobs:
       filePath: '$(Build.Repository.LocalPath)\build\mvnBuildAndPackage.ps1'
       arguments: '-mvnPrefix ''$(mvnPrefix)'''
   - publish: $(Build.Repository.LocalPath)\packages\Microsoft.Azure.WebJobs.Extensions.RabbitMQ
-    artifact: Nuget
+    artifact: Microsoft.Azure.WebJobs.Extensions.RabbitMQ.${{ variables.releaseVersionNumber }}
   - publish: $(Build.Repository.LocalPath)\binding-library\java\ToBePublished
-    artifact: Java
+    artifact: ${{ variables.mvnPrefix }}
 
 - job: RunTests
   pool:

--- a/binding-library/java/mvnBuild.bat
+++ b/binding-library/java/mvnBuild.bat
@@ -1,0 +1,1 @@
+mvn clean install -U -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B -Dgpg.skip

--- a/binding-library/java/pom.xml
+++ b/binding-library/java/pom.xml
@@ -126,6 +126,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${maven-javadoc.version}</version>
+                <configuration>
+                    <doclint>none</doclint>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/binding-library/java/pom.xml
+++ b/binding-library/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.microsoft.azure.functions</groupId>
     <artifactId>azure-functions-java-library-rabbitmq</artifactId>
-    <version>1.0.0-beta</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <parent>
         <groupId>com.microsoft.maven</groupId>

--- a/build/initialize-pipeline.ps1
+++ b/build/initialize-pipeline.ps1
@@ -1,8 +1,16 @@
 param(
-	[Parameter(Mandatory=$true)][string]$versionPath
+	[Parameter(Mandatory=$true)][string]$versionPath,
+	[Parameter(Mandatory=$true)][string]$javaPath
 )
 
-# Figure out the build number
+#Figure out mvn build number
+[XML]$xmlContent = Get-Content "$javaPath\\pom.xml"
+$artifactId = $xmlContent.project.artifactId
+$version = $xmlContent.project.version
+$outputXmlFileName = "$artifactid-$version"
+Write-Host "##vso[task.setvariable variable=MvnPackagePrefix;isOutput=true]$outputXmlFileName"
+
+# Figure out nuget build number
 $xml = [Xml] (Get-Content "$versionPath\\WebJobs.Extensions.RabbitMQ.csproj")
 $version = ([string]($xml.Project.PropertyGroup.Version)).Trim()
 

--- a/build/initialize-pipeline.ps1
+++ b/build/initialize-pipeline.ps1
@@ -4,10 +4,11 @@ param(
 )
 
 #Figure out mvn build number
-[XML]$xmlContent = Get-Content "$javaPath\\pom.xml"
+$xmlContent = [XML] (Get-Content "$javaPath\\pom.xml")
 $artifactId = $xmlContent.project.artifactId
 $version = $xmlContent.project.version
-$outputXmlFileName = "$artifactid-$version"
+$outputXmlFileName = ([string] ("$artifactid-$version")).Trim()
+Write-Host "Prefix generated from pom.xml is $outputXmlFileName"
 Write-Host "##vso[task.setvariable variable=MvnPackagePrefix;isOutput=true]$outputXmlFileName"
 
 # Figure out nuget build number

--- a/build/mvnBuild.ps1
+++ b/build/mvnBuild.ps1
@@ -1,2 +1,2 @@
-cd ../binding-library/java
+cd binding-library/java
 cmd.exe /c 'mvnBuild.bat'

--- a/build/mvnBuild.ps1
+++ b/build/mvnBuild.ps1
@@ -1,1 +1,2 @@
-cmd.exe /c '../binding-library/java/mvnBuild.bat'
+cd ../binding-library/java
+cmd.exe /c 'mvnBuild.bat'

--- a/build/mvnBuild.ps1
+++ b/build/mvnBuild.ps1
@@ -1,2 +1,0 @@
-cd binding-library/java
-cmd.exe /c 'mvnBuild.bat'

--- a/build/mvnBuild.ps1
+++ b/build/mvnBuild.ps1
@@ -1,0 +1,1 @@
+cmd.exe /c '../binding-library/java/mvnBuild.bat'

--- a/build/mvnBuildAndPackage.ps1
+++ b/build/mvnBuildAndPackage.ps1
@@ -9,4 +9,14 @@ cd binding-library/java
 .\mvnBuild.bat
 
 #Copy pom.xml to target fileName
-Copy-Item pom.xml "target\$mvnPrefix.xml"
+#Copy-Item pom.xml "target\$mvnPrefix.xml"
+
+#Copy items to be published
+mkdir ToBePublished
+Copy-Item pom.xml "ToBePublished\$mvnPrefix.xml"
+Copy-Item "target\$mvnPrefix.jar" "ToBePublished\$mvnPrefix.jar"
+Copy-Item "target\$mvnPrefix-javadoc.jar" "ToBePublished\$mvnPrefix-javadoc.jar"
+Copy-Item "target\$mvnPrefix-sources.jar" "ToBePublished\$mvnPrefix-sources.jar"
+
+
+

--- a/build/mvnBuildAndPackage.ps1
+++ b/build/mvnBuildAndPackage.ps1
@@ -8,9 +8,6 @@ Write-Host "Mvn prefix is $mvnPrefix"
 cd binding-library/java
 .\mvnBuild.bat
 
-#Copy pom.xml to target fileName
-#Copy-Item pom.xml "target\$mvnPrefix.xml"
-
 #Copy items to be published
 mkdir ToBePublished
 Copy-Item pom.xml "ToBePublished\$mvnPrefix.xml"

--- a/build/mvnBuildAndPackage.ps1
+++ b/build/mvnBuildAndPackage.ps1
@@ -1,0 +1,14 @@
+cd ../binding-library/java
+
+#Build artifact and version
+[XML]$xmlContent = Get-Content pom.xml
+$artifactId = $xmlContent.project.artifactId
+$version = $xmlContent.project.version
+$outputXmlFileName = "$artifactid-$version.xml"
+Write-Host "##vso[task.setvariable variable=MvnPackagePrefix;isOutput=true]$outputXmlFileName"
+
+#Build
+#.\mvnBuild.bat
+
+#Copy pom.xml to target fileName
+Copy-Item pom.xml "target\$outputXmlFileName"

--- a/build/mvnBuildAndPackage.ps1
+++ b/build/mvnBuildAndPackage.ps1
@@ -5,7 +5,7 @@ cd binding-library/java
 $artifactId = $xmlContent.project.artifactId
 $version = $xmlContent.project.version
 $outputXmlFileName = "$artifactid-$version"
-# Write-Host "##vso[task.setvariable variable=MvnPackagePrefix;isOutput=true]$outputXmlFileName"
+Write-Host "##vso[task.setvariable variable=MvnPackagePrefix;isOutput=true]$outputXmlFileName"
 
 #Build
 .\mvnBuild.bat
@@ -14,7 +14,7 @@ $outputXmlFileName = "$artifactid-$version"
 Copy-Item pom.xml "target\$outputXmlFileName.xml"
 
 #Copy to artifact staging directory
-Copy-Item -Path "target\$outputXmlFileName.xml" -Destination $(Build.ArtifactStagingDirectory) -ErrorAction Stop -Verbose -Force
-Copy-Item -Path "target\$outputXmlFileName.jar" -Destination $(Build.ArtifactStagingDirectory) -ErrorAction Stop -Verbose -Force
-Copy-Item -Path "target\$outputXmlFileName-javadoc.jar" -Destination $(Build.ArtifactStagingDirectory) -ErrorAction Stop -Verbose -Force
-Copy-Item -Path "target\$outputXmlFileName-sources.jar" -Destination $(Build.ArtifactStagingDirectory) -ErrorAction Stop -Verbose -Force
+#Copy-Item -Path "target\$outputXmlFileName.xml" -Destination $(Build.ArtifactStagingDirectory) -ErrorAction Stop -Verbose -Force
+#Copy-Item -Path "target\$outputXmlFileName.jar" -Destination $(Build.ArtifactStagingDirectory) -ErrorAction Stop -Verbose -Force
+#Copy-Item -Path "target\$outputXmlFileName-javadoc.jar" -Destination $(Build.ArtifactStagingDirectory) -ErrorAction Stop -Verbose -Force
+#Copy-Item -Path "target\$outputXmlFileName-sources.jar" -Destination $(Build.ArtifactStagingDirectory) -ErrorAction Stop -Verbose -Force

--- a/build/mvnBuildAndPackage.ps1
+++ b/build/mvnBuildAndPackage.ps1
@@ -1,14 +1,20 @@
-cd ../binding-library/java
+cd binding-library/java
 
 #Build artifact and version
 [XML]$xmlContent = Get-Content pom.xml
 $artifactId = $xmlContent.project.artifactId
 $version = $xmlContent.project.version
-$outputXmlFileName = "$artifactid-$version.xml"
-Write-Host "##vso[task.setvariable variable=MvnPackagePrefix;isOutput=true]$outputXmlFileName"
+$outputXmlFileName = "$artifactid-$version"
+# Write-Host "##vso[task.setvariable variable=MvnPackagePrefix;isOutput=true]$outputXmlFileName"
 
 #Build
-#.\mvnBuild.bat
+.\mvnBuild.bat
 
 #Copy pom.xml to target fileName
-Copy-Item pom.xml "target\$outputXmlFileName"
+Copy-Item pom.xml "target\$outputXmlFileName.xml"
+
+#Copy to artifact staging directory
+Copy-Item -Path "target\$outputXmlFileName.xml" -Destination $(Build.ArtifactStagingDirectory) -ErrorAction Stop -Verbose -Force
+Copy-Item -Path "target\$outputXmlFileName.jar" -Destination $(Build.ArtifactStagingDirectory) -ErrorAction Stop -Verbose -Force
+Copy-Item -Path "target\$outputXmlFileName-javadoc.jar" -Destination $(Build.ArtifactStagingDirectory) -ErrorAction Stop -Verbose -Force
+Copy-Item -Path "target\$outputXmlFileName-sources.jar" -Destination $(Build.ArtifactStagingDirectory) -ErrorAction Stop -Verbose -Force

--- a/build/mvnBuildAndPackage.ps1
+++ b/build/mvnBuildAndPackage.ps1
@@ -1,20 +1,6 @@
-cd binding-library/java
-
-#Build artifact and version
-[XML]$xmlContent = Get-Content pom.xml
-$artifactId = $xmlContent.project.artifactId
-$version = $xmlContent.project.version
-$outputXmlFileName = "$artifactid-$version"
-Write-Host "##vso[task.setvariable variable=MvnPackagePrefix;isOutput=true]$outputXmlFileName"
-
 #Build
+cd binding-library/java
 .\mvnBuild.bat
 
 #Copy pom.xml to target fileName
 Copy-Item pom.xml "target\$outputXmlFileName.xml"
-
-#Copy to artifact staging directory
-#Copy-Item -Path "target\$outputXmlFileName.xml" -Destination $(Build.ArtifactStagingDirectory) -ErrorAction Stop -Verbose -Force
-#Copy-Item -Path "target\$outputXmlFileName.jar" -Destination $(Build.ArtifactStagingDirectory) -ErrorAction Stop -Verbose -Force
-#Copy-Item -Path "target\$outputXmlFileName-javadoc.jar" -Destination $(Build.ArtifactStagingDirectory) -ErrorAction Stop -Verbose -Force
-#Copy-Item -Path "target\$outputXmlFileName-sources.jar" -Destination $(Build.ArtifactStagingDirectory) -ErrorAction Stop -Verbose -Force

--- a/build/mvnBuildAndPackage.ps1
+++ b/build/mvnBuildAndPackage.ps1
@@ -1,6 +1,12 @@
+param(
+	[Parameter(Mandatory=$true)][string]$mvnPrefix
+)
+
+Write-Host "Mvn prefix is $mvnPrefix"
+
 #Build
 cd binding-library/java
 .\mvnBuild.bat
 
 #Copy pom.xml to target fileName
-Copy-Item pom.xml "target\$outputXmlFileName.xml"
+Copy-Item pom.xml "target\$mvnPrefix.xml"


### PR DESCRIPTION
Building and publishing packages as described in doc. Below is copy paste from one note

Java to maven central (via oss.sonatype.org )
Files: The release job expects the following set of files:

<library>.pom – Renamed version of pom.xml that was used to build the library
<library>.jar - Must always provide for library projects.
<library>-javadoc.jar - Must always provide for library projects.
<library>-sources.jar - Must always provide for library projects.
where <library> is the standard library name and version that maven projects produce for the jar files.

Sample build with both nuget and java : https://azfunc.visualstudio.com/Azure%20Functions/_build/results?buildId=9287&view=artifacts&type=publishedArtifacts