### PR TITLE
Adding ability to send response to an exchange and not just a queue

### DIFF
--- a/src/Bindings/RabbitMQAsyncCollector.cs
+++ b/src/Bindings/RabbitMQAsyncCollector.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         }
 
         public Task AddAsync(byte[] message, CancellationToken cancellationToken = default)
-        {
-            _batch.Add(exchange: string.Empty, routingKey: _context.ResolvedAttribute.QueueName, mandatory: false, properties: null, body: message);
+        {            
+            _batch.Add(exchange: _context.ResolvedAttribute.ExchangeName, routingKey: _context.ResolvedAttribute.QueueName, mandatory: false, properties: null, body: message);
             _logger.LogDebug($"Adding message to batch for publishing...");
 
             return Task.CompletedTask;

--- a/src/Bindings/RabbitMQAsyncCollector.cs
+++ b/src/Bindings/RabbitMQAsyncCollector.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         }
 
         public Task AddAsync(byte[] message, CancellationToken cancellationToken = default)
-        {            
+        {
             _batch.Add(exchange: _context.ResolvedAttribute.ExchangeName, routingKey: _context.ResolvedAttribute.QueueName, mandatory: false, properties: null, body: message);
             _logger.LogDebug($"Adding message to batch for publishing...");
 

--- a/src/Config/DefaultRabbitMQServiceFactory.cs
+++ b/src/Config/DefaultRabbitMQServiceFactory.cs
@@ -5,9 +5,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     internal class DefaultRabbitMQServiceFactory : IRabbitMQServiceFactory
     {
-        public IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port)
+        public IRabbitMQService CreateService(string connectionString, string queueName, string exchangeName, string hostName,  string userName, string password, int port)
         {
-            return new RabbitMQService(connectionString, hostName, queueName, userName, password, port);
+            return new RabbitMQService(connectionString, queueName, exchangeName, hostName, userName, password, port);
         }
 
         public IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port)

--- a/src/Config/IRabbitMQServiceFactory.cs
+++ b/src/Config/IRabbitMQServiceFactory.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     public interface IRabbitMQServiceFactory
     {
-        IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port);
+        IRabbitMQService CreateService(string connectionString, string queueName, string exchangeName, string hostName, string userName, string password, int port);
 
         IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port);
     }

--- a/src/Config/RabbitMQExtensionConfigProvider.cs
+++ b/src/Config/RabbitMQExtensionConfigProvider.cs
@@ -73,13 +73,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             {
                 throw new InvalidOperationException("RabbitMQ username and password required if not connecting to localhost");
             }
+
+            string queueName = Utility.FirstOrDefault(attribute.QueueName, _options.Value.QueueName);
+            string exchangeName = Utility.FirstOrDefault(attribute.ExchangeName, _options.Value.ExchangeName);
+            _logger.LogInformation($"Queue: {queueName} and Exchange {exchangeName}");
+            if (string.IsNullOrEmpty(queueName) && string.IsNullOrEmpty(exchangeName))
+            {
+                throw new InvalidOperationException("One of queueName or exchangeName should be provided");
+            }
         }
 
         internal RabbitMQContext CreateContext(RabbitMQAttribute attribute)
         {
             string connectionString = Utility.FirstOrDefault(attribute.ConnectionStringSetting, _options.Value.ConnectionString);
             string hostName = Utility.FirstOrDefault(attribute.HostName, _options.Value.HostName);
-            string queueName = Utility.FirstOrDefault(attribute.QueueName, _options.Value.QueueName);
+            string queueName = Utility.FirstOrDefault(attribute.QueueName, _options.Value.QueueName) ?? string.Empty;
+            string exchangeName = Utility.FirstOrDefault(attribute.ExchangeName, _options.Value.ExchangeName) ?? string.Empty;
             string userName = Utility.FirstOrDefault(attribute.UserName, _options.Value.UserName);
             string password = Utility.FirstOrDefault(attribute.Password, _options.Value.Password);
             int port = Utility.FirstOrDefault(attribute.Port, _options.Value.Port);
@@ -92,12 +101,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 ConnectionStringSetting = connectionString,
                 HostName = hostName,
                 QueueName = queueName,
+                ExchangeName = exchangeName,
                 UserName = userName,
                 Password = password,
                 Port = port,
             };
 
-            service = GetService(connectionString, hostName, queueName, userName, password, port);
+            service = GetService(connectionString, queueName, exchangeName, hostName, userName, password, port);
 
             return new RabbitMQContext
             {
@@ -106,9 +116,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             };
         }
 
-        internal IRabbitMQService GetService(string connectionString, string hostName, string queueName, string userName, string password, int port)
+        internal IRabbitMQService GetService(string connectionString, string queueName, string exchangeName, string hostName, string userName, string password, int port)
         {
-            return _rabbitMQServiceFactory.CreateService(connectionString, hostName, queueName, userName, password, port);
+            return _rabbitMQServiceFactory.CreateService(connectionString, queueName, exchangeName, hostName, userName, password, port);
         }
 
         // Overloaded method used only for getting the RabbitMQ client

--- a/src/Config/RabbitMQOptions.cs
+++ b/src/Config/RabbitMQOptions.cs
@@ -28,6 +28,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         public string QueueName { get; set; }
 
         /// <summary>
+        /// Gets or sets the ExchangeName to enqueue messages to.
+        /// </summary>
+        public string ExchangeName { get; set; }
+
+        /// <summary>
         /// Gets or sets the UserName used to authenticate with RabbitMQ.
         /// </summary>
         public string UserName { get; set; }
@@ -58,6 +63,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             {
                 { nameof(HostName), HostName },
                 { nameof(QueueName), QueueName },
+                { nameof(ExchangeName), ExchangeName },
                 { nameof(Port), Port },
                 { nameof(PrefetchCount), PrefetchCount },
             };

--- a/src/RabbitMQAttribute.cs
+++ b/src/RabbitMQAttribute.cs
@@ -52,12 +52,11 @@ namespace Microsoft.Azure.WebJobs
         /// </summary>
         [ConnectionString]
         public string ConnectionStringSetting { get; set; }
-		
-		/// <summary>
+
+        /// <summary>
         /// Gets or sets the ExchangeName to send messages to.
         /// </summary>
-
-		[AutoResolve]
+        [AutoResolve]
         public string ExchangeName { get; set; }
     }
 }

--- a/src/RabbitMQAttribute.cs
+++ b/src/RabbitMQAttribute.cs
@@ -28,6 +28,9 @@ namespace Microsoft.Azure.WebJobs
         [AutoResolve]
         public string QueueName { get; set; }
 
+        [AutoResolve]
+        public string ExchangeName { get; set; }
+
         [AppSetting]
         public string UserName { get; set; }
 

--- a/src/RabbitMQAttribute.cs
+++ b/src/RabbitMQAttribute.cs
@@ -27,10 +27,7 @@ namespace Microsoft.Azure.WebJobs
         // </summary>
         [AutoResolve]
         public string QueueName { get; set; }
-
-        [AutoResolve]
-        public string ExchangeName { get; set; }
-
+        
         [AppSetting]
         public string UserName { get; set; }
 
@@ -42,5 +39,8 @@ namespace Microsoft.Azure.WebJobs
 
         [ConnectionString]
         public string ConnectionStringSetting { get; set; }
+		
+		[AutoResolve]
+        public string ExchangeName { get; set; }
     }
 }

--- a/src/Services/RabbitMQService.cs
+++ b/src/Services/RabbitMQService.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         private readonly string _connectionString;
         private readonly string _hostName;
         private readonly string _queueName;
+        private readonly string _exchangeName;
         private readonly string _userName;
         private readonly string _password;
         private readonly int _port;
@@ -31,13 +32,23 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             _model = connectionFactory.CreateConnection().CreateModel();
         }
 
-        public RabbitMQService(string connectionString, string hostName, string queueName, string userName, string password, int port)
+        public RabbitMQService(string connectionString, string queueName, string exchangeName, string hostName, string userName, string password, int port)
             : this(connectionString, hostName, userName, password, port)
         {
             _rabbitMQModel = new RabbitMQModel(_model);
             _queueName = queueName ?? throw new ArgumentNullException(nameof(queueName));
+            _exchangeName = exchangeName ?? throw new ArgumentNullException(nameof(exchangeName));
 
-            _model.QueueDeclarePassive(_queueName); // Throws exception if queue doesn't exist
+            if (!string.IsNullOrEmpty(_queueName))
+            {
+                _model.QueueDeclarePassive(_queueName);
+            }
+
+            if (!string.IsNullOrEmpty(_exchangeName))
+            {
+                _model.ExchangeDeclarePassive(_exchangeName); // Throws exception if exchange doesn't exist
+            }
+
             _batch = _model.CreateBasicPublishBatch();
         }
 

--- a/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
+++ b/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 throw new InvalidOperationException("RabbitMQ username and password required if not connecting to localhost");
             }
 
-            IRabbitMQService service = _provider.GetService(connectionString, hostName, queueName, userName, password, port);
+            IRabbitMQService service = _provider.GetService(connectionString, queueName, string.Empty, hostName, userName, password, port);
 
             return Task.FromResult<ITriggerBinding>(new RabbitMQTriggerBinding(service, hostName, queueName, _logger, parameter.ParameterType, _options.Value.PrefetchCount));
         }

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQOptionsTests.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQOptionsTests.cs
@@ -19,6 +19,7 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
             {
                 { nameof(option.HostName), option.HostName },
                 { nameof(option.QueueName), option.QueueName },
+                { nameof(option.ExchangeName), option.ExchangeName },
                 { nameof(option.Port), option.Port },
                 { nameof(option.PrefetchCount), option.PrefetchCount },
             };
@@ -50,6 +51,7 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
             int expectedPort = 8080;
             string expectedHostName = "someHostName";
             string expectedQueueName = "someQueueName";
+            string expectedExchangeName = "someExchangeName";
             string expectedUserName = "someUserName";
             string expectedPassword = "somePassword";
             string expectedConnectionString = "someConnectionString";
@@ -58,6 +60,7 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
                 Port = expectedPort,
                 HostName = expectedHostName,
                 QueueName = expectedQueueName,
+                ExchangeName = expectedExchangeName,
                 UserName = expectedUserName,
                 Password = expectedPassword,
                 ConnectionString = expectedConnectionString,
@@ -68,6 +71,7 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
             Assert.Equal(expectedPort, options.Port);
             Assert.Equal(expectedHostName, options.HostName);
             Assert.Equal(expectedQueueName, options.QueueName);
+            Assert.Equal(expectedExchangeName, options.ExchangeName);
             Assert.Equal(expectedUserName, options.UserName);
             Assert.Equal(expectedPassword, options.Password);
             Assert.Equal(expectedConnectionString, options.ConnectionString);


### PR DESCRIPTION
By adding ability to send response to an exchange we can effectively send response to multiple queues if required.

This solution can be enhanced to send response to an exchange with routing key.