### PR TITLE
Fix System.ObjectDisposedException when calling StopAsync()

### DIFF
--- a/src/Trigger/RabbitMQListener.cs
+++ b/src/Trigger/RabbitMQListener.cs
@@ -81,6 +81,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
         public void Cancel()
         {
+            if (!_started)
+            {
+                return;
+            }
+
             StopAsync(CancellationToken.None).Wait();
         }
 


### PR DESCRIPTION
Hello

There is a crash when stopping the webjob.

I use this in tests to start/stop some services and when it crash it prevent other services to be disposed / stopped gracefully, and the test process is stuck

```
            var host = builder.Build();
            using (host)
            {
                await host.StartAsync();
                await Task.Delay(2_000);
                await host.StopAsync();
            }
```