### PR TITLE
Add parameters to set Acceptable policy errors when connecting over TLS

### DIFF
--- a/src/Bindings/RabbitMQClientBuilder.cs
+++ b/src/Bindings/RabbitMQClientBuilder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net.Security;
 using Microsoft.Extensions.Options;
 using RabbitMQ.Client;
 
@@ -39,7 +40,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             string resolvedPassword = Utility.FirstOrDefault(attribute.Password, _options.Value.Password);
             int resolvedPort = Utility.FirstOrDefault(attribute.Port, _options.Value.Port);
 
-            IRabbitMQService service = _configProvider.GetService(resolvedConnectionString, resolvedHostName, resolvedUserName, resolvedPassword, resolvedPort);
+            SslPolicyErrors acceptablePolicyErrors = attribute.AcceptablePolicyErrors;
+
+            IRabbitMQService service = _configProvider.GetService(resolvedConnectionString, resolvedHostName, resolvedUserName, resolvedPassword, resolvedPort, acceptablePolicyErrors);
 
             return service.Model;
         }

--- a/src/Config/DefaultRabbitMQServiceFactory.cs
+++ b/src/Config/DefaultRabbitMQServiceFactory.cs
@@ -1,18 +1,20 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Net.Security;
+
 namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     internal class DefaultRabbitMQServiceFactory : IRabbitMQServiceFactory
     {
-        public IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port)
+        public IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port, SslPolicyErrors acceptablePolicyErrors)
         {
-            return new RabbitMQService(connectionString, hostName, queueName, userName, password, port);
+            return new RabbitMQService(connectionString, hostName, queueName, userName, password, port, acceptablePolicyErrors);
         }
 
-        public IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port)
+        public IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port, SslPolicyErrors acceptablePolicyErrors)
         {
-            return new RabbitMQService(connectionString, hostName, userName, password, port);
+            return new RabbitMQService(connectionString, hostName, userName, password, port, acceptablePolicyErrors);
         }
     }
 }

--- a/src/Config/IRabbitMQServiceFactory.cs
+++ b/src/Config/IRabbitMQServiceFactory.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Net.Security;
+
 namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     public interface IRabbitMQServiceFactory
     {
-        IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port);
+        IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port, SslPolicyErrors acceptablePolicyErrors);
 
-        IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port);
+        IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port, SslPolicyErrors acceptablePolicyErrors);
     }
 }

--- a/src/Config/RabbitMQExtensionConfigProvider.cs
+++ b/src/Config/RabbitMQExtensionConfigProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Net.Security;
 using System.Text;
 using Microsoft.Azure.WebJobs.Description;
 using Microsoft.Azure.WebJobs.Host.Bindings;
@@ -83,6 +84,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             string userName = Utility.FirstOrDefault(attribute.UserName, _options.Value.UserName);
             string password = Utility.FirstOrDefault(attribute.Password, _options.Value.Password);
             int port = Utility.FirstOrDefault(attribute.Port, _options.Value.Port);
+            SslPolicyErrors acceptablePolicyErrors = attribute.AcceptablePolicyErrors;
 
             RabbitMQAttribute resolvedAttribute;
             IRabbitMQService service;
@@ -95,9 +97,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 UserName = userName,
                 Password = password,
                 Port = port,
+                AcceptablePolicyErrors = acceptablePolicyErrors,
             };
 
-            service = GetService(connectionString, hostName, queueName, userName, password, port);
+            service = GetService(connectionString, hostName, queueName, userName, password, port, acceptablePolicyErrors);
 
             return new RabbitMQContext
             {
@@ -106,15 +109,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             };
         }
 
-        internal IRabbitMQService GetService(string connectionString, string hostName, string queueName, string userName, string password, int port)
+        internal IRabbitMQService GetService(string connectionString, string hostName, string queueName, string userName, string password, int port, SslPolicyErrors acceptablePolicyErrors)
         {
-            return _rabbitMQServiceFactory.CreateService(connectionString, hostName, queueName, userName, password, port);
+            return _rabbitMQServiceFactory.CreateService(connectionString, hostName, queueName, userName, password, port, acceptablePolicyErrors);
         }
 
         // Overloaded method used only for getting the RabbitMQ client
-        internal IRabbitMQService GetService(string connectionString, string hostName, string userName, string password, int port)
+        internal IRabbitMQService GetService(string connectionString, string hostName, string userName, string password, int port, SslPolicyErrors acceptablePolicyErrors)
         {
-            return _rabbitMQServiceFactory.CreateService(connectionString, hostName, userName, password, port);
+            return _rabbitMQServiceFactory.CreateService(connectionString, hostName, userName, password, port, acceptablePolicyErrors);
         }
     }
 }

--- a/src/RabbitMQAttribute.cs
+++ b/src/RabbitMQAttribute.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Net.Security;
 using Microsoft.Azure.WebJobs.Description;
 
 namespace Microsoft.Azure.WebJobs
@@ -52,5 +53,10 @@ namespace Microsoft.Azure.WebJobs
         /// </summary>
         [ConnectionString]
         public string ConnectionStringSetting { get; set; }
+
+        /// <summary>
+        /// Gets or sets the acceptable policy errors when connecting to RabbitMQ over TLS. Defaults to RemoteCertificateNameMismatch, which is the default for the .Net RabbitMQ client.
+        /// </summary>
+        public SslPolicyErrors AcceptablePolicyErrors { get; set; } = SslPolicyErrors.RemoteCertificateNameMismatch;
     }
 }

--- a/src/Services/RabbitMQService.cs
+++ b/src/Services/RabbitMQService.cs
@@ -2,6 +2,9 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Net.Security;
+using System.Reflection;
+using System.Security.Cryptography.X509Certificates;
 using RabbitMQ.Client;
 
 namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
@@ -17,22 +20,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         private readonly string _userName;
         private readonly string _password;
         private readonly int _port;
+        private readonly SslPolicyErrors _acceptablePolicyErrors;
 
-        public RabbitMQService(string connectionString, string hostName, string userName, string password, int port)
+        public RabbitMQService(string connectionString, string hostName, string userName, string password, int port, SslPolicyErrors acceptablePolicyErrors)
         {
             _connectionString = connectionString;
             _hostName = hostName;
             _userName = userName;
             _password = password;
             _port = port;
+            _acceptablePolicyErrors = acceptablePolicyErrors;
 
-            ConnectionFactory connectionFactory = GetConnectionFactory(_connectionString, _hostName, _userName, _password, _port);
+            ConnectionFactory connectionFactory = GetConnectionFactory(_connectionString, _hostName, _userName, _password, _port, _acceptablePolicyErrors);
 
-            _model = connectionFactory.CreateConnection().CreateModel();
+            _model = connectionFactory.CreateConnection(Assembly.GetEntryAssembly().GetName().Name).CreateModel();
         }
 
-        public RabbitMQService(string connectionString, string hostName, string queueName, string userName, string password, int port)
-            : this(connectionString, hostName, userName, password, port)
+        public RabbitMQService(string connectionString, string hostName, string queueName, string userName, string password, int port, SslPolicyErrors acceptablePolicyErrors)
+            : this(connectionString, hostName, userName, password, port, acceptablePolicyErrors)
         {
             _rabbitMQModel = new RabbitMQModel(_model);
             _queueName = queueName ?? throw new ArgumentNullException(nameof(queueName));
@@ -47,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
         public IBasicPublishBatch BasicPublishBatch => _batch;
 
-        internal static ConnectionFactory GetConnectionFactory(string connectionString, string hostName, string userName, string password, int port)
+        internal static ConnectionFactory GetConnectionFactory(string connectionString, string hostName, string userName, string password, int port, SslPolicyErrors acceptablePolicyErrors)
         {
             ConnectionFactory connectionFactory = new ConnectionFactory();
 
@@ -55,6 +60,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             if (!string.IsNullOrEmpty(connectionString))
             {
                 connectionFactory.Uri = new Uri(connectionString);
+
+                if (connectionString.StartsWith("amqps://"))
+                {
+                    connectionFactory.Ssl.AcceptablePolicyErrors = acceptablePolicyErrors;
+                }
             }
             else
             {

--- a/src/Trigger/RabbitMQTriggerAttribute.cs
+++ b/src/Trigger/RabbitMQTriggerAttribute.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Net.Security;
 using Microsoft.Azure.WebJobs.Description;
 
 namespace Microsoft.Azure.WebJobs
@@ -60,5 +61,10 @@ namespace Microsoft.Azure.WebJobs
         /// Gets or sets the Port used. Defaults to 0.
         /// </summary>
         public int Port { get; set; }
+
+        /// <summary>
+        /// Gets or sets the acceptable policy errors when connecting to RabbitMQ over TLS. Defaults to RemoteCertificateNameMismatch, which is the default for the .Net RabbitMQ client.
+        /// </summary>
+        public SslPolicyErrors AcceptablePolicyErrors { get; set; } = SslPolicyErrors.RemoteCertificateNameMismatch;
     }
 }

--- a/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
+++ b/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Net.Security;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host;
@@ -61,12 +62,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
             int port = attribute.Port;
 
+            SslPolicyErrors acceptablePolicyErrors = attribute.AcceptablePolicyErrors;
+
             if (string.IsNullOrEmpty(connectionString) && !Utility.ValidateUserNamePassword(userName, password, hostName))
             {
                 throw new InvalidOperationException("RabbitMQ username and password required if not connecting to localhost");
             }
 
-            IRabbitMQService service = _provider.GetService(connectionString, hostName, queueName, userName, password, port);
+            IRabbitMQService service = _provider.GetService(connectionString, hostName, queueName, userName, password, port, acceptablePolicyErrors);
 
             return Task.FromResult<ITriggerBinding>(new RabbitMQTriggerBinding(service, hostName, queueName, _logger, parameter.ParameterType, _options.Value.PrefetchCount));
         }

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQClientBuilderTests.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQClientBuilderTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using RabbitMQ.Client;
+using System.Net.Security;
 using Xunit;
 
 namespace WebJobs.Extensions.RabbitMQ.Tests
@@ -23,13 +24,13 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
             var options = new OptionsWrapper<RabbitMQOptions>(new RabbitMQOptions { HostName = Constants.LocalHost });
             var mockServiceFactory = new Mock<IRabbitMQServiceFactory>();
             var config = new RabbitMQExtensionConfigProvider(options, new Mock<INameResolver>().Object, mockServiceFactory.Object, new LoggerFactory(), _emptyConfig);
-            mockServiceFactory.Setup(m => m.CreateService(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>())).Returns(new Mock<IRabbitMQService>().Object);
+            mockServiceFactory.Setup(m => m.CreateService(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<SslPolicyErrors>())).Returns(new Mock<IRabbitMQService>().Object);
             RabbitMQAttribute attr = GetTestAttribute();
 
             RabbitMQClientBuilder clientBuilder = new RabbitMQClientBuilder(config, options);
             var model = clientBuilder.Convert(attr);
 
-            mockServiceFactory.Verify(m => m.CreateService(It.IsAny<string>(), Constants.LocalHost, "guest", "guest", 5672), Times.Exactly(1));
+            mockServiceFactory.Verify(m => m.CreateService(It.IsAny<string>(), Constants.LocalHost, "guest", "guest", 5672, It.IsAny<SslPolicyErrors>()), Times.Exactly(1));
         }
 
         [Fact]
@@ -37,7 +38,7 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
         {
             var options = new OptionsWrapper<RabbitMQOptions>(new RabbitMQOptions { HostName = Constants.LocalHost });
             var mockServiceFactory = new Mock<IRabbitMQServiceFactory>();
-            mockServiceFactory.SetupSequence(m => m.CreateService(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()))
+            mockServiceFactory.SetupSequence(m => m.CreateService(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<SslPolicyErrors>()))
                 .Returns(GetRabbitMQService())
                 .Returns(GetRabbitMQService());
             var config = new RabbitMQExtensionConfigProvider(options, new Mock<INameResolver>().Object, mockServiceFactory.Object, new LoggerFactory(), _emptyConfig);


### PR DESCRIPTION
When making a connection to the RabbitMQ broker over TLS the RabbitMQ .Net Client rejects the connection if the certificates configured on the broker are self signed and not considered 'trusted'. This PR allows the passing of the `SslPolicyErrors` enum as a parameter to indicate which errors are acceptable for TLS connections.