### PR TITLE
Service pooling with rabbitmq

### DIFF
--- a/src/Bindings/RabbitMQClientBuilder.cs
+++ b/src/Bindings/RabbitMQClientBuilder.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using Microsoft.Extensions.Options;
 using RabbitMQ.Client;
 
@@ -12,18 +11,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
     {
         private readonly RabbitMQExtensionConfigProvider _configProvider;
         private readonly IOptions<RabbitMQOptions> _options;
-        private readonly IDictionary<RabbitMQAttribute, IModel> _rabbitMQAttributeToModel;
 
         public RabbitMQClientBuilder(RabbitMQExtensionConfigProvider configProvider, IOptions<RabbitMQOptions> options)
         {
             _configProvider = configProvider;
             _options = options;
-            _rabbitMQAttributeToModel = new Dictionary<RabbitMQAttribute, IModel>();
         }
 
         public IModel Convert(RabbitMQAttribute attribute)
         {
-            return GetOrCreateModel(attribute);
+            return CreateModelFromAttribute(attribute);
         }
 
         private IModel CreateModelFromAttribute(RabbitMQAttribute attribute)
@@ -42,17 +39,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             IRabbitMQService service = _configProvider.GetService(resolvedConnectionString, resolvedHostName, resolvedUserName, resolvedPassword, resolvedPort);
 
             return service.Model;
-        }
-
-        private IModel GetOrCreateModel(RabbitMQAttribute attribute)
-        {
-            if (!_rabbitMQAttributeToModel.TryGetValue(attribute, out IModel rabbitMQModel))
-            {
-                rabbitMQModel = CreateModelFromAttribute(attribute);
-                _rabbitMQAttributeToModel.Add(attribute, rabbitMQModel);
-            }
-
-            return rabbitMQModel;
         }
     }
 }

--- a/src/Config/RabbitMQExtensionConfigProvider.cs
+++ b/src/Config/RabbitMQExtensionConfigProvider.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         private readonly IRabbitMQServiceFactory _rabbitMQServiceFactory;
         private readonly ILogger _logger;
         private readonly IConfiguration _configuration;
-        private readonly ConcurrentDictionary<string, IRabbitMQService> _connectionParamtersToService;
+        private readonly ConcurrentDictionary<string, IRabbitMQService> _connectionParametersToService;
 
         public RabbitMQExtensionConfigProvider(IOptions<RabbitMQOptions> options, INameResolver nameResolver, IRabbitMQServiceFactory rabbitMQServiceFactory, ILoggerFactory loggerFactory, IConfiguration configuration)
         {
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             _rabbitMQServiceFactory = rabbitMQServiceFactory;
             _logger = loggerFactory?.CreateLogger(LogCategories.CreateTriggerCategory("RabbitMQ"));
             _configuration = configuration;
-            _connectionParamtersToService = new ConcurrentDictionary<string, IRabbitMQService>();
+            _connectionParametersToService = new ConcurrentDictionary<string, IRabbitMQService>();
         }
 
         public void Initialize(ExtensionConfigContext context)
@@ -112,14 +112,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         internal IRabbitMQService GetService(string connectionString, string hostName, string queueName, string userName, string password, int port)
         {
             string key = string.Join(connectionString, ",", hostName, ",", queueName, ",", userName, ",", password, ",", port);
-            return _connectionParamtersToService.GetOrAdd(key, _ => _rabbitMQServiceFactory.CreateService(connectionString, hostName, queueName, userName, password, port));
+            return _connectionParametersToService.GetOrAdd(key, _ => _rabbitMQServiceFactory.CreateService(connectionString, hostName, queueName, userName, password, port));
         }
 
         // Overloaded method used only for getting the RabbitMQ client
         internal IRabbitMQService GetService(string connectionString, string hostName, string userName, string password, int port)
         {
             string key = string.Join(connectionString, ",", hostName, ",", userName, ",", password, ",", port);
-            return _connectionParamtersToService.GetOrAdd(key, _ => _rabbitMQServiceFactory.CreateService(connectionString, hostName, userName, password, port));
+            return _connectionParametersToService.GetOrAdd(key, _ => _rabbitMQServiceFactory.CreateService(connectionString, hostName, userName, password, port));
         }
     }
 }

--- a/src/Config/RabbitMQExtensionConfigProvider.cs
+++ b/src/Config/RabbitMQExtensionConfigProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Text;
 using Microsoft.Azure.WebJobs.Description;
 using Microsoft.Azure.WebJobs.Host.Bindings;
@@ -22,6 +23,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         private readonly IRabbitMQServiceFactory _rabbitMQServiceFactory;
         private readonly ILogger _logger;
         private readonly IConfiguration _configuration;
+        private readonly ConcurrentDictionary<string, IRabbitMQService> _connectionParamtersToService;
 
         public RabbitMQExtensionConfigProvider(IOptions<RabbitMQOptions> options, INameResolver nameResolver, IRabbitMQServiceFactory rabbitMQServiceFactory, ILoggerFactory loggerFactory, IConfiguration configuration)
         {
@@ -30,6 +32,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             _rabbitMQServiceFactory = rabbitMQServiceFactory;
             _logger = loggerFactory?.CreateLogger(LogCategories.CreateTriggerCategory("RabbitMQ"));
             _configuration = configuration;
+            _connectionParamtersToService = new ConcurrentDictionary<string, IRabbitMQService>();
         }
 
         public void Initialize(ExtensionConfigContext context)
@@ -108,13 +111,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
         internal IRabbitMQService GetService(string connectionString, string hostName, string queueName, string userName, string password, int port)
         {
-            return _rabbitMQServiceFactory.CreateService(connectionString, hostName, queueName, userName, password, port);
+            string key = string.Join(connectionString, ",", hostName, ",", queueName, ",", userName, ",", password, ",", port);
+            return _connectionParamtersToService.GetOrAdd(key, _ => _rabbitMQServiceFactory.CreateService(connectionString, hostName, queueName, userName, password, port));
         }
 
         // Overloaded method used only for getting the RabbitMQ client
         internal IRabbitMQService GetService(string connectionString, string hostName, string userName, string password, int port)
         {
-            return _rabbitMQServiceFactory.CreateService(connectionString, hostName, userName, password, port);
+            string key = string.Join(connectionString, ",", hostName, ",", userName, ",", password, ",", port);
+            return _connectionParamtersToService.GetOrAdd(key, _ => _rabbitMQServiceFactory.CreateService(connectionString, hostName, userName, password, port));
         }
     }
 }

--- a/src/Config/RabbitMQExtensionConfigProvider.cs
+++ b/src/Config/RabbitMQExtensionConfigProvider.cs
@@ -111,14 +111,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
         internal IRabbitMQService GetService(string connectionString, string hostName, string queueName, string userName, string password, int port)
         {
-            string key = string.Join(connectionString, ",", hostName, ",", queueName, ",", userName, ",", password, ",", port);
+            string[] keyArray = { connectionString, hostName, queueName, userName, password, port.ToString() };
+            string key = string.Join(",", keyArray);
             return _connectionParametersToService.GetOrAdd(key, _ => _rabbitMQServiceFactory.CreateService(connectionString, hostName, queueName, userName, password, port));
         }
 
         // Overloaded method used only for getting the RabbitMQ client
         internal IRabbitMQService GetService(string connectionString, string hostName, string userName, string password, int port)
         {
-            string key = string.Join(connectionString, ",", hostName, ",", userName, ",", password, ",", port);
+            string[] keyArray = { connectionString, hostName, userName, password, port.ToString() };
+            string key = string.Join(",", keyArray);
             return _connectionParametersToService.GetOrAdd(key, _ => _rabbitMQServiceFactory.CreateService(connectionString, hostName, userName, password, port));
         }
     }

--- a/src/Services/IRabbitMQService.cs
+++ b/src/Services/IRabbitMQService.cs
@@ -12,5 +12,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         IModel Model { get; }
 
         IBasicPublishBatch BasicPublishBatch { get; }
+
+        public void ResetPublishBatch();
     }
 }

--- a/src/Services/RabbitMQService.cs
+++ b/src/Services/RabbitMQService.cs
@@ -10,13 +10,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
     {
         private readonly IRabbitMQModel _rabbitMQModel;
         private readonly IModel _model;
-        private readonly IBasicPublishBatch _batch;
         private readonly string _connectionString;
         private readonly string _hostName;
         private readonly string _queueName;
         private readonly string _userName;
         private readonly string _password;
         private readonly int _port;
+
+        private IBasicPublishBatch _batch;
 
         public RabbitMQService(string connectionString, string hostName, string userName, string password, int port)
         {
@@ -46,6 +47,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         public IModel Model => _model;
 
         public IBasicPublishBatch BasicPublishBatch => _batch;
+
+        // Typically called after a flush
+        public void ResetPublishBatch()
+        {
+            _batch = _model.CreateBasicPublishBatch();
+        }
 
         internal static ConnectionFactory GetConnectionFactory(string connectionString, string hostName, string userName, string password, int port)
         {

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQExtensionConfigProviderTests.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQExtensionConfigProviderTests.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.RabbitMQ;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace WebJobs.Extensions.RabbitMQ.Tests
+{
+    public class RabbitMQExtensionConfigProviderTests
+    {
+        [Fact]
+        public void TestConnectionPooling()
+        {
+            var rabbitmqServiceFactory = new Mock<IRabbitMQServiceFactory>();
+
+
+            rabbitmqServiceFactory.SetupSequence(a => a.CreateService(
+               It.IsAny<string>(),
+               It.IsAny<string>(),
+               It.IsAny<string>(),
+               It.IsAny<string>(),
+               It.IsAny<string>(),
+               It.IsAny<int>())).Returns(new Mock<IRabbitMQService>().Object)
+               .Returns(new Mock<IRabbitMQService>().Object)
+               .Returns(new Mock<IRabbitMQService>().Object)
+               .Returns(new Mock<IRabbitMQService>().Object);
+
+            rabbitmqServiceFactory.SetupSequence(a => a.CreateService(
+               It.IsAny<string>(),
+               It.IsAny<string>(),
+               It.IsAny<string>(),
+               It.IsAny<string>(),
+               It.IsAny<int>())).Returns(new Mock<IRabbitMQService>().Object)
+               .Returns(new Mock<IRabbitMQService>().Object)
+               .Returns(new Mock<IRabbitMQService>().Object)
+               .Returns(new Mock<IRabbitMQService>().Object);
+
+            RabbitMQExtensionConfigProvider extensionConfigProvider = new RabbitMQExtensionConfigProvider(
+                new Mock<IOptions<RabbitMQOptions>>().Object,
+                new Mock<INameResolver>().Object,
+                rabbitmqServiceFactory.Object,
+                NullLoggerFactory.Instance,
+                new Mock<IConfiguration>().Object);
+
+            var rabbitmqService1 = extensionConfigProvider.GetService("something", "something", "something", "something", 80);
+            var rabbitmqService2 = extensionConfigProvider.GetService("something", "something", "something", "something", 80);
+            var rabbitmqService3 = extensionConfigProvider.GetService("somethingElse", "something", "something", "something", 80);
+
+            // 1 and 2 should be equal
+            Assert.Equal(rabbitmqService1, rabbitmqService2);
+
+            // 3 shouldn't be equal to 1 nor 2
+            Assert.NotEqual(rabbitmqService1, rabbitmqService3);
+            Assert.NotEqual(rabbitmqService2, rabbitmqService3);
+
+            var rabbitmqService4 = extensionConfigProvider.GetService("asomething", "asomething", "asomething", "asomething", "asomething", 80);
+            var rabbitmqService5 = extensionConfigProvider.GetService("asomething", "asomething", "asomething", "asomething", "asomething", 80);
+            var rabbitmqService6 = extensionConfigProvider.GetService("asomethingElse", "asomething", "asomething", "asomething", "asomething", 80);
+
+            // 4 and 5 should be equal
+            Assert.Equal(rabbitmqService4, rabbitmqService5);
+
+            // 6 shouldn't be equal to 4 or 5
+            Assert.NotEqual(rabbitmqService6, rabbitmqService4);
+            Assert.NotEqual(rabbitmqService6, rabbitmqService5);
+        }
+    }
+}


### PR DESCRIPTION
RabbitMQ service is not being pooled for every output binding invocation. As a result, every invocation of IAsyncCollector creates a new service.

This PR pools instances of IRabbitMQService. This also means that Batch needs to be reset upon every `FlushAsync()` call and the PR handles that as well.