### PR TITLE
Add lock for RabbitMQService

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,1 +1,3 @@
 ### Release notes
+
+# Added pooling for RabbitMQService

--- a/src/Bindings/RabbitMQAsyncCollector.cs
+++ b/src/Bindings/RabbitMQAsyncCollector.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         {
             _logger.LogDebug($"Adding message to batch for publishing...");
 
-            lock (_context.Service)
+            lock (_context.Service.PublishBatchLock)
             {
                 _context.Service.BasicPublishBatch.Add(exchange: string.Empty, routingKey: _context.ResolvedAttribute.QueueName, mandatory: false, properties: null, body: message);
             }
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         {
             _logger.LogDebug($"Publishing messages to queue.");
 
-            lock (_context.Service)
+            lock (_context.Service.PublishBatchLock)
             {
                 _context.Service.BasicPublishBatch.Publish();
                 _context.Service.ResetPublishBatch();

--- a/src/Bindings/RabbitMQAsyncCollector.cs
+++ b/src/Bindings/RabbitMQAsyncCollector.cs
@@ -25,8 +25,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
         public Task AddAsync(byte[] message, CancellationToken cancellationToken = default)
         {
-            _context.Service.BasicPublishBatch.Add(exchange: string.Empty, routingKey: _context.ResolvedAttribute.QueueName, mandatory: false, properties: null, body: message);
             _logger.LogDebug($"Adding message to batch for publishing...");
+
+            lock (_context.Service)
+            {
+                _context.Service.BasicPublishBatch.Add(exchange: string.Empty, routingKey: _context.ResolvedAttribute.QueueName, mandatory: false, properties: null, body: message);
+            }
+
             return Task.CompletedTask;
         }
 
@@ -37,9 +42,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
         internal Task PublishAsync()
         {
-            _context.Service.BasicPublishBatch.Publish();
             _logger.LogDebug($"Publishing messages to queue.");
-            _context.Service.ResetPublishBatch();
+
+            lock (_context.Service)
+            {
+                _context.Service.BasicPublishBatch.Publish();
+                _context.Service.ResetPublishBatch();
+            }
+
             return Task.CompletedTask;
         }
     }

--- a/src/Services/IRabbitMQService.cs
+++ b/src/Services/IRabbitMQService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
         IBasicPublishBatch BasicPublishBatch { get; }
 
-        public void ResetPublishBatch();
+        object PublishBatchLock { get; }
+
+        void ResetPublishBatch();
     }
 }

--- a/src/Services/RabbitMQService.cs
+++ b/src/Services/RabbitMQService.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         private readonly string _userName;
         private readonly string _password;
         private readonly int _port;
+        private readonly object _publishBatchLock;
 
         private IBasicPublishBatch _batch;
 
@@ -30,6 +31,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             ConnectionFactory connectionFactory = GetConnectionFactory(_connectionString, _hostName, _userName, _password, _port);
 
             _model = connectionFactory.CreateConnection().CreateModel();
+            _publishBatchLock = new object();
         }
 
         public RabbitMQService(string connectionString, string hostName, string queueName, string userName, string password, int port)
@@ -47,6 +49,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         public IModel Model => _model;
 
         public IBasicPublishBatch BasicPublishBatch => _batch;
+
+        public object PublishBatchLock => _publishBatchLock;
 
         // Typically called after a flush
         public void ResetPublishBatch()

--- a/src/WebJobs.Extensions.RabbitMQ.csproj
+++ b/src/WebJobs.Extensions.RabbitMQ.csproj
@@ -9,7 +9,7 @@
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>PublicKey.snk</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>
-    <Version>1.2.0</Version>
+    <Version>1.1.0</Version>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.RabbitMQ</PackageId>
     <Authors>Microsoft</Authors>
     <Product>Azure WebJobs RabbitMQ Extension</Product>

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQAsyncCollectorTests.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQAsyncCollectorTests.cs
@@ -19,9 +19,11 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
         [Fact]
         public async Task AddAsync_AddsMessagesToQueue()
         {
+            var batchLock = new object();
             var mockRabbitMQService = new Mock<IRabbitMQService>(MockBehavior.Strict);
             var mockBatch = new Mock<IBasicPublishBatch>();
             mockRabbitMQService.Setup(m => m.BasicPublishBatch).Returns(mockBatch.Object);
+            mockRabbitMQService.Setup(m => m.PublishBatchLock).Returns(batchLock);
 
             var attribute = new RabbitMQAttribute
             {


### PR DESCRIPTION
Added lock to ensure `batch.Add()` and `flush()` don't happen simultaneously.