### PR TITLE
Prevent package reference RabbitMQ.Client v 6.x

### DIFF
--- a/src/WebJobs.Extensions.RabbitMQ.csproj
+++ b/src/WebJobs.Extensions.RabbitMQ.csproj
@@ -47,7 +47,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.14" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.1.2" />
+    <PackageReference Include="RabbitMQ.Client" Version="[5.1.2,6.0)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
As we don't have support for `RabbitMQ.Client` 6.x #92, we should prevent that version. This fixes #89.