### PR TITLE
Allow SSL for AMQP connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The above sample waits on a trigger from the queue named "queue" connected to th
 |HostName|(ignored if using ConnectionStringSetting) Hostname of the queue|`10.26.45.210`|
 |UserName|(ignored if using ConnectionStringSetting) User name to access queue|`user`|
 |Password|(ignored if using ConnectionStringSetting) Password to access queue|`password`|
+|Ssl|Bool to enable or disable SSL in AMQP connection (default false)|`true`|
+|InsecureSsl|Bool to enable or disable checking certificate when Ssl=true (default false. Not recommended for production)|`true`|
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ The above sample waits on a trigger from the queue named "queue" connected to th
 |HostName|(ignored if using ConnectionStringSetting) Hostname of the queue|`10.26.45.210`|
 |UserName|(ignored if using ConnectionStringSetting) User name to access queue|`user`|
 |Password|(ignored if using ConnectionStringSetting) Password to access queue|`password`|
-|Ssl|Bool to enable or disable SSL in AMQP connection (default false)|`true`|
-|InsecureSsl|Bool to enable or disable checking certificate when Ssl=true (default false. Not recommended for production)|`true`|
+|EnableSsl|Bool to enable or disable SSL in AMQP connection (default false)|`true`|
+|SkipCertificateValidation|Bool to enable or disable checking certificate when EnableSsl=true. It will accept RemoteCertificateChainErrors and RemoteCertificateNameMismatch errors (default false. Not recommended for production)|`true`|
 
 # Contributing
 

--- a/binding-library/java/src/main/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQOutput.java
+++ b/binding-library/java/src/main/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQOutput.java
@@ -85,11 +85,11 @@ public @interface RabbitMQOutput {
      * Enable or disable ssl in RabbitMQ connection.
      * @return A bool to enable Ssl.
      */
-    bool enableSsl() default false;
+    boolean enableSsl() default false;
 
     /**
      * Enable os disable checking certificate when Ssl is enabled (not recommended for production).
      * @return A bool to enable checking certificates when Ssl is enabled.
      */
-    bool skipCertificateValidation() default false;
+    boolean skipCertificateValidation() default false;
 }

--- a/binding-library/java/src/main/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQOutput.java
+++ b/binding-library/java/src/main/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQOutput.java
@@ -80,4 +80,16 @@ public @interface RabbitMQOutput {
      * @return The port to attach.
      */
     int port() default 0;
+
+    /**
+     * Enable or disable ssl in RabbitMQ connection.
+     * @return A bool to enable Ssl.
+     */
+    bool enableSsl() default false;
+
+    /**
+     * Enable os disable checking certificate when Ssl is enabled (not recommended for production).
+     * @return A bool to enable checking certificates when Ssl is enabled.
+     */
+    bool skipCertificateValidation() default false;
 }

--- a/binding-library/java/src/main/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQTrigger.java
+++ b/binding-library/java/src/main/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQTrigger.java
@@ -81,11 +81,11 @@ public @interface RabbitMQTrigger {
      * Enable or disable ssl in RabbitMQ connection.
      * @return A bool to enable Ssl.
      */
-    bool enableSsl() default false;
+    boolean enableSsl() default false;
 
     /**
      * Enable os disable checking certificate when Ssl is enabled (not recommended for production).
      * @return A bool to enable checking certificates when Ssl is enabled.
      */
-    bool skipCertificateValidation() default false;
+    boolean skipCertificateValidation() default false;
 }

--- a/binding-library/java/src/main/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQTrigger.java
+++ b/binding-library/java/src/main/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQTrigger.java
@@ -76,4 +76,16 @@ public @interface RabbitMQTrigger {
      * @return The port to attach.
      */
     int port() default 0;
+
+    /**
+     * Enable or disable ssl in RabbitMQ connection.
+     * @return A bool to enable Ssl.
+     */
+    bool enableSsl() default false;
+
+    /**
+     * Enable os disable checking certificate when Ssl is enabled (not recommended for production).
+     * @return A bool to enable checking certificates when Ssl is enabled.
+     */
+    bool skipCertificateValidation() default false;
 }

--- a/binding-library/java/test/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQOutputTests.java
+++ b/binding-library/java/test/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQOutputTests.java
@@ -21,6 +21,8 @@ public class RabbitMQOutputTests {
         EasyMock.expect(outputInterface.userName()).andReturn("randomUserName");
         EasyMock.expect(outputInterface.connectionStringSetting()).andReturn("randomConnectionStringSetting");
         EasyMock.expect(outputInterface.port()).andReturn(123);
+        EasyMock.expect(outputInterface.enableSsl()).andReturn(false);
+        EasyMock.expect(outputInterface.skipCertificateValidation()).andReturn(false);
 
         EasyMock.replay(outputInterface);
     }

--- a/binding-library/java/test/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQTriggerTests.java
+++ b/binding-library/java/test/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQTriggerTests.java
@@ -21,6 +21,8 @@ public class RabbitMQTriggerTests {
         EasyMock.expect(triggerInterface.userNameSetting()).andReturn("randomUserName");
         EasyMock.expect(triggerInterface.connectionStringSetting()).andReturn("randomConnectionStringSetting");
         EasyMock.expect(triggerInterface.port()).andReturn(123);
+        EasyMock.expect(triggerInterface.enableSsl()).andReturn(false);
+        EasyMock.expect(triggerInterface.skipCertificateValidation()).andReturn(false);
 
         EasyMock.replay(triggerInterface);
     }

--- a/src/Bindings/RabbitMQClientBuilder.cs
+++ b/src/Bindings/RabbitMQClientBuilder.cs
@@ -35,10 +35,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             string resolvedUserName = Utility.FirstOrDefault(attribute.UserName, _options.Value.UserName);
             string resolvedPassword = Utility.FirstOrDefault(attribute.Password, _options.Value.Password);
             int resolvedPort = Utility.FirstOrDefault(attribute.Port, _options.Value.Port);
-            bool resolvedSsl = Utility.FirstOrDefault(attribute.Ssl, _options.Value.Ssl);
-            bool resolvedInsecureSsl = Utility.FirstOrDefault(attribute.InsecureSsl, _options.Value.InsecureSsl);
+            bool resolvedEnableSsl = Utility.FirstOrDefault(attribute.EnableSsl, _options.Value.EnableSsl);
+            bool resolvedSkipCertificateValidation = Utility.FirstOrDefault(attribute.SkipCertificateValidation, _options.Value.SkipCertificateValidation);
 
-            IRabbitMQService service = _configProvider.GetService(resolvedConnectionString, resolvedHostName, resolvedUserName, resolvedPassword, resolvedPort, resolvedSsl, resolvedInsecureSsl);
+            IRabbitMQService service = _configProvider.GetService(resolvedConnectionString, resolvedHostName, resolvedUserName, resolvedPassword, resolvedPort, resolvedEnableSsl, resolvedSkipCertificateValidation);
 
             return service.Model;
         }

--- a/src/Bindings/RabbitMQClientBuilder.cs
+++ b/src/Bindings/RabbitMQClientBuilder.cs
@@ -35,8 +35,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             string resolvedUserName = Utility.FirstOrDefault(attribute.UserName, _options.Value.UserName);
             string resolvedPassword = Utility.FirstOrDefault(attribute.Password, _options.Value.Password);
             int resolvedPort = Utility.FirstOrDefault(attribute.Port, _options.Value.Port);
+            bool resolvedSsl = Utility.FirstOrDefault(attribute.Ssl, _options.Value.Ssl);
 
-            IRabbitMQService service = _configProvider.GetService(resolvedConnectionString, resolvedHostName, resolvedUserName, resolvedPassword, resolvedPort);
+            IRabbitMQService service = _configProvider.GetService(resolvedConnectionString, resolvedHostName, resolvedUserName, resolvedPassword, resolvedPort, resolvedSsl);
 
             return service.Model;
         }

--- a/src/Bindings/RabbitMQClientBuilder.cs
+++ b/src/Bindings/RabbitMQClientBuilder.cs
@@ -36,8 +36,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             string resolvedPassword = Utility.FirstOrDefault(attribute.Password, _options.Value.Password);
             int resolvedPort = Utility.FirstOrDefault(attribute.Port, _options.Value.Port);
             bool resolvedSsl = Utility.FirstOrDefault(attribute.Ssl, _options.Value.Ssl);
+            bool resolvedInsecureSsl = Utility.FirstOrDefault(attribute.InsecureSsl, _options.Value.InsecureSsl);
 
-            IRabbitMQService service = _configProvider.GetService(resolvedConnectionString, resolvedHostName, resolvedUserName, resolvedPassword, resolvedPort, resolvedSsl);
+            IRabbitMQService service = _configProvider.GetService(resolvedConnectionString, resolvedHostName, resolvedUserName, resolvedPassword, resolvedPort, resolvedSsl, resolvedInsecureSsl);
 
             return service.Model;
         }

--- a/src/Config/DefaultRabbitMQServiceFactory.cs
+++ b/src/Config/DefaultRabbitMQServiceFactory.cs
@@ -5,14 +5,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     internal class DefaultRabbitMQServiceFactory : IRabbitMQServiceFactory
     {
-        public IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port)
+        public IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port, bool ssl)
         {
-            return new RabbitMQService(connectionString, hostName, queueName, userName, password, port);
+            return new RabbitMQService(connectionString, hostName, queueName, userName, password, port, ssl);
         }
 
-        public IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port)
+        public IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port, bool ssl)
         {
-            return new RabbitMQService(connectionString, hostName, userName, password, port);
+            return new RabbitMQService(connectionString, hostName, userName, password, port, ssl);
         }
     }
 }

--- a/src/Config/DefaultRabbitMQServiceFactory.cs
+++ b/src/Config/DefaultRabbitMQServiceFactory.cs
@@ -5,14 +5,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     internal class DefaultRabbitMQServiceFactory : IRabbitMQServiceFactory
     {
-        public IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port, bool ssl)
+        public IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port, bool ssl, bool insecureSsl)
         {
-            return new RabbitMQService(connectionString, hostName, queueName, userName, password, port, ssl);
+            return new RabbitMQService(connectionString, hostName, queueName, userName, password, port, ssl, insecureSsl);
         }
 
-        public IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port, bool ssl)
+        public IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port, bool ssl, bool insecureSsl)
         {
-            return new RabbitMQService(connectionString, hostName, userName, password, port, ssl);
+            return new RabbitMQService(connectionString, hostName, userName, password, port, ssl, insecureSsl);
         }
     }
 }

--- a/src/Config/IRabbitMQServiceFactory.cs
+++ b/src/Config/IRabbitMQServiceFactory.cs
@@ -5,8 +5,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     public interface IRabbitMQServiceFactory
     {
-        IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port, bool ssl, bool insecureSsl);
+        IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port, bool enableSsl, bool skipCertificateValidation);
 
-        IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port, bool ssl, bool insecureSsl);
+        IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port, bool enableSsl, bool kipCertificateValidation);
     }
 }

--- a/src/Config/IRabbitMQServiceFactory.cs
+++ b/src/Config/IRabbitMQServiceFactory.cs
@@ -7,6 +7,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
     {
         IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port, bool enableSsl, bool skipCertificateValidation);
 
-        IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port, bool enableSsl, bool kipCertificateValidation);
+        IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port, bool enableSsl, bool skipCertificateValidation);
     }
 }

--- a/src/Config/IRabbitMQServiceFactory.cs
+++ b/src/Config/IRabbitMQServiceFactory.cs
@@ -5,8 +5,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     public interface IRabbitMQServiceFactory
     {
-        IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port);
+        IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port, bool ssl);
 
-        IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port);
+        IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port, bool ssl);
     }
 }

--- a/src/Config/IRabbitMQServiceFactory.cs
+++ b/src/Config/IRabbitMQServiceFactory.cs
@@ -5,8 +5,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     public interface IRabbitMQServiceFactory
     {
-        IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port, bool ssl);
+        IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port, bool ssl, bool insecureSsl);
 
-        IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port, bool ssl);
+        IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port, bool ssl, bool insecureSsl);
     }
 }

--- a/src/Config/RabbitMQExtensionConfigProvider.cs
+++ b/src/Config/RabbitMQExtensionConfigProvider.cs
@@ -86,6 +86,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             string userName = Utility.FirstOrDefault(attribute.UserName, _options.Value.UserName);
             string password = Utility.FirstOrDefault(attribute.Password, _options.Value.Password);
             int port = Utility.FirstOrDefault(attribute.Port, _options.Value.Port);
+            bool ssl = Utility.FirstOrDefault(attribute.Ssl, _options.Value.Ssl);
 
             RabbitMQAttribute resolvedAttribute;
             IRabbitMQService service;
@@ -98,9 +99,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 UserName = userName,
                 Password = password,
                 Port = port,
+                Ssl = ssl,
             };
 
-            service = GetService(connectionString, hostName, queueName, userName, password, port);
+            service = GetService(connectionString, hostName, queueName, userName, password, port, ssl);
 
             return new RabbitMQContext
             {
@@ -109,19 +111,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             };
         }
 
-        internal IRabbitMQService GetService(string connectionString, string hostName, string queueName, string userName, string password, int port)
+        internal IRabbitMQService GetService(string connectionString, string hostName, string queueName, string userName, string password, int port, bool ssl)
         {
             string[] keyArray = { connectionString, hostName, queueName, userName, password, port.ToString() };
             string key = string.Join(",", keyArray);
-            return _connectionParametersToService.GetOrAdd(key, _ => _rabbitMQServiceFactory.CreateService(connectionString, hostName, queueName, userName, password, port));
+            return _connectionParametersToService.GetOrAdd(key, _ => _rabbitMQServiceFactory.CreateService(connectionString, hostName, queueName, userName, password, port, ssl));
         }
 
         // Overloaded method used only for getting the RabbitMQ client
-        internal IRabbitMQService GetService(string connectionString, string hostName, string userName, string password, int port)
+        internal IRabbitMQService GetService(string connectionString, string hostName, string userName, string password, int port, bool ssl)
         {
             string[] keyArray = { connectionString, hostName, userName, password, port.ToString() };
             string key = string.Join(",", keyArray);
-            return _connectionParametersToService.GetOrAdd(key, _ => _rabbitMQServiceFactory.CreateService(connectionString, hostName, userName, password, port));
+            return _connectionParametersToService.GetOrAdd(key, _ => _rabbitMQServiceFactory.CreateService(connectionString, hostName, userName, password, port, ssl));
         }
     }
 }

--- a/src/Config/RabbitMQExtensionConfigProvider.cs
+++ b/src/Config/RabbitMQExtensionConfigProvider.cs
@@ -87,6 +87,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             string password = Utility.FirstOrDefault(attribute.Password, _options.Value.Password);
             int port = Utility.FirstOrDefault(attribute.Port, _options.Value.Port);
             bool ssl = Utility.FirstOrDefault(attribute.Ssl, _options.Value.Ssl);
+            bool insecureSsl = Utility.FirstOrDefault(attribute.InsecureSsl, _options.Value.InsecureSsl);
 
             RabbitMQAttribute resolvedAttribute;
             IRabbitMQService service;
@@ -100,9 +101,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 Password = password,
                 Port = port,
                 Ssl = ssl,
+                InsecureSsl = insecureSsl,
             };
 
-            service = GetService(connectionString, hostName, queueName, userName, password, port, ssl);
+            service = GetService(connectionString, hostName, queueName, userName, password, port, ssl, insecureSsl);
 
             return new RabbitMQContext
             {
@@ -111,19 +113,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             };
         }
 
-        internal IRabbitMQService GetService(string connectionString, string hostName, string queueName, string userName, string password, int port, bool ssl)
+        internal IRabbitMQService GetService(string connectionString, string hostName, string queueName, string userName, string password, int port, bool ssl, bool insecureSsl)
         {
             string[] keyArray = { connectionString, hostName, queueName, userName, password, port.ToString() };
             string key = string.Join(",", keyArray);
-            return _connectionParametersToService.GetOrAdd(key, _ => _rabbitMQServiceFactory.CreateService(connectionString, hostName, queueName, userName, password, port, ssl));
+            return _connectionParametersToService.GetOrAdd(key, _ => _rabbitMQServiceFactory.CreateService(connectionString, hostName, queueName, userName, password, port, ssl, insecureSsl));
         }
 
         // Overloaded method used only for getting the RabbitMQ client
-        internal IRabbitMQService GetService(string connectionString, string hostName, string userName, string password, int port, bool ssl)
+        internal IRabbitMQService GetService(string connectionString, string hostName, string userName, string password, int port, bool ssl, bool insecureSsl)
         {
             string[] keyArray = { connectionString, hostName, userName, password, port.ToString() };
             string key = string.Join(",", keyArray);
-            return _connectionParametersToService.GetOrAdd(key, _ => _rabbitMQServiceFactory.CreateService(connectionString, hostName, userName, password, port, ssl));
+            return _connectionParametersToService.GetOrAdd(key, _ => _rabbitMQServiceFactory.CreateService(connectionString, hostName, userName, password, port, ssl, insecureSsl));
         }
     }
 }

--- a/src/Config/RabbitMQExtensionConfigProvider.cs
+++ b/src/Config/RabbitMQExtensionConfigProvider.cs
@@ -86,8 +86,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             string userName = Utility.FirstOrDefault(attribute.UserName, _options.Value.UserName);
             string password = Utility.FirstOrDefault(attribute.Password, _options.Value.Password);
             int port = Utility.FirstOrDefault(attribute.Port, _options.Value.Port);
-            bool ssl = Utility.FirstOrDefault(attribute.Ssl, _options.Value.Ssl);
-            bool insecureSsl = Utility.FirstOrDefault(attribute.InsecureSsl, _options.Value.InsecureSsl);
+            bool enableSsl = Utility.FirstOrDefault(attribute.EnableSsl, _options.Value.EnableSsl);
+            bool skipCertificateValidation = Utility.FirstOrDefault(attribute.SkipCertificateValidation, _options.Value.SkipCertificateValidation);
 
             RabbitMQAttribute resolvedAttribute;
             IRabbitMQService service;
@@ -100,11 +100,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 UserName = userName,
                 Password = password,
                 Port = port,
-                Ssl = ssl,
-                InsecureSsl = insecureSsl,
+                EnableSsl = enableSsl,
+                SkipCertificateValidation = skipCertificateValidation,
             };
 
-            service = GetService(connectionString, hostName, queueName, userName, password, port, ssl, insecureSsl);
+            service = GetService(connectionString, hostName, queueName, userName, password, port, enableSsl, skipCertificateValidation);
 
             return new RabbitMQContext
             {
@@ -113,19 +113,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             };
         }
 
-        internal IRabbitMQService GetService(string connectionString, string hostName, string queueName, string userName, string password, int port, bool ssl, bool insecureSsl)
+        internal IRabbitMQService GetService(string connectionString, string hostName, string queueName, string userName, string password, int port, bool enableSsl, bool skipCertificateValidation)
         {
             string[] keyArray = { connectionString, hostName, queueName, userName, password, port.ToString() };
             string key = string.Join(",", keyArray);
-            return _connectionParametersToService.GetOrAdd(key, _ => _rabbitMQServiceFactory.CreateService(connectionString, hostName, queueName, userName, password, port, ssl, insecureSsl));
+            return _connectionParametersToService.GetOrAdd(key, _ => _rabbitMQServiceFactory.CreateService(connectionString, hostName, queueName, userName, password, port, enableSsl, skipCertificateValidation));
         }
 
         // Overloaded method used only for getting the RabbitMQ client
-        internal IRabbitMQService GetService(string connectionString, string hostName, string userName, string password, int port, bool ssl, bool insecureSsl)
+        internal IRabbitMQService GetService(string connectionString, string hostName, string userName, string password, int port, bool enableSsl, bool skipCertificateValidation)
         {
             string[] keyArray = { connectionString, hostName, userName, password, port.ToString() };
             string key = string.Join(",", keyArray);
-            return _connectionParametersToService.GetOrAdd(key, _ => _rabbitMQServiceFactory.CreateService(connectionString, hostName, userName, password, port, ssl, insecureSsl));
+            return _connectionParametersToService.GetOrAdd(key, _ => _rabbitMQServiceFactory.CreateService(connectionString, hostName, userName, password, port, enableSsl, skipCertificateValidation));
         }
     }
 }

--- a/src/Config/RabbitMQOptions.cs
+++ b/src/Config/RabbitMQOptions.cs
@@ -48,6 +48,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         public int Port { get; set; }
 
         /// <summary>
+        /// Enable or disable ssl in RabbitMQ connection.
+        /// </summary>
+        public bool Ssl { get; set; }
+
+        /// <summary>
         /// Gets or sets the prefetch count while creating the RabbitMQ QoS. This seting controls how many values are cached.
         /// </summary>
         public ushort PrefetchCount { get; set; }

--- a/src/Config/RabbitMQOptions.cs
+++ b/src/Config/RabbitMQOptions.cs
@@ -50,12 +50,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         /// <summary>
         /// Enable or disable ssl in RabbitMQ connection.
         /// </summary>
-        public bool Ssl { get; set; }
+        public bool EnableSsl { get; set; }
 
         /// <summary>
         /// Enable os disable checking certificate when Ssl is enabled (not recommended for production).
         /// </summary>
-        public bool InsecureSsl { get; set; }
+        public bool SkipCertificateValidation { get; set; }
 
         /// <summary>
         /// Gets or sets the prefetch count while creating the RabbitMQ QoS. This seting controls how many values are cached.

--- a/src/Config/RabbitMQOptions.cs
+++ b/src/Config/RabbitMQOptions.cs
@@ -53,6 +53,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         public bool Ssl { get; set; }
 
         /// <summary>
+        /// Enable os disable checking certificate when Ssl is enabled (not recommended for production).
+        /// </summary>
+        public bool InsecureSsl { get; set; }
+
+        /// <summary>
         /// Gets or sets the prefetch count while creating the RabbitMQ QoS. This seting controls how many values are cached.
         /// </summary>
         public ushort PrefetchCount { get; set; }

--- a/src/RabbitMQAttribute.cs
+++ b/src/RabbitMQAttribute.cs
@@ -56,11 +56,11 @@ namespace Microsoft.Azure.WebJobs
         /// <summary>
         /// Enable or disable ssl in RabbitMQ connection.
         /// </summary>
-        public bool Ssl { get; set; }
+        public bool EnableSsl { get; set; }
 
         /// <summary>
         /// Enable os disable checking certificate when Ssl is enabled (not recommended for production).
         /// </summary>
-        public bool InsecureSsl { get; set; }
+        public bool SkipCertificateValidation { get; set; }
     }
 }

--- a/src/RabbitMQAttribute.cs
+++ b/src/RabbitMQAttribute.cs
@@ -57,5 +57,10 @@ namespace Microsoft.Azure.WebJobs
         /// Enable or disable ssl in RabbitMQ connection.
         /// </summary>
         public bool Ssl { get; set; }
+
+        /// <summary>
+        /// Enable os disable checking certificate when Ssl is enabled (not recommended for production).
+        /// </summary>
+        public bool InsecureSsl { get; set; }
     }
 }

--- a/src/RabbitMQAttribute.cs
+++ b/src/RabbitMQAttribute.cs
@@ -52,5 +52,10 @@ namespace Microsoft.Azure.WebJobs
         /// </summary>
         [ConnectionString]
         public string ConnectionStringSetting { get; set; }
+
+        /// <summary>
+        /// Enable or disable ssl in RabbitMQ connection.
+        /// </summary>
+        public bool Ssl { get; set; }
     }
 }

--- a/src/Services/RabbitMQService.cs
+++ b/src/Services/RabbitMQService.cs
@@ -70,14 +70,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             // Only set these if specified by user. Otherwise, API will use default parameters.
             if (!string.IsNullOrEmpty(connectionString))
             {
-                amqpUri = new Uri(connectionString);
+                Uri amqpUri = new Uri(connectionString);
                 connectionFactory.Uri = amqpUri;
-                if (ssl)
-                {
-                    Uri amqpUri = new Uri(connectionString);
-                    connectionFactory.Uri = amqpUri;
-                    ConfigureSsl(connectionFactory, amqpUri.Host, ssl, insecureSsl);
-                }
+                ConfigureSsl(connectionFactory, amqpUri.Host, ssl, insecureSsl);
             }
             else
             {

--- a/src/Services/RabbitMQService.cs
+++ b/src/Services/RabbitMQService.cs
@@ -17,30 +17,30 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         private readonly string _userName;
         private readonly string _password;
         private readonly int _port;
-        private readonly bool _ssl;
-        private readonly bool _insecureSsl;
+        private readonly bool _enableSsl;
+        private readonly bool _skipCertificateValidation;
         private readonly object _publishBatchLock;
 
         private IBasicPublishBatch _batch;
 
-        public RabbitMQService(string connectionString, string hostName, string userName, string password, int port, bool ssl, bool insecureSsl)
+        public RabbitMQService(string connectionString, string hostName, string userName, string password, int port, bool enableSsl, bool skipCertificateValidation)
         {
             _connectionString = connectionString;
             _hostName = hostName;
             _userName = userName;
             _password = password;
             _port = port;
-            _ssl = ssl;
-            _insecureSsl = insecureSsl;
+            _enableSsl = enableSsl;
+            _skipCertificateValidation = skipCertificateValidation;
 
-            ConnectionFactory connectionFactory = GetConnectionFactory(_connectionString, _hostName, _userName, _password, _port, _ssl, _insecureSsl);
+            ConnectionFactory connectionFactory = GetConnectionFactory(_connectionString, _hostName, _userName, _password, _port, _enableSsl, _skipCertificateValidation);
 
             _model = connectionFactory.CreateConnection().CreateModel();
             _publishBatchLock = new object();
         }
 
-        public RabbitMQService(string connectionString, string hostName, string queueName, string userName, string password, int port, bool ssl, bool insecureSsl)
-            : this(connectionString, hostName, userName, password, port, ssl, insecureSsl)
+        public RabbitMQService(string connectionString, string hostName, string queueName, string userName, string password, int port, bool enableSsl, bool skipCertificateValidation)
+            : this(connectionString, hostName, userName, password, port, enableSsl, skipCertificateValidation)
         {
             _rabbitMQModel = new RabbitMQModel(_model);
             _queueName = queueName ?? throw new ArgumentNullException(nameof(queueName));
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             _batch = _model.CreateBasicPublishBatch();
         }
 
-        internal static ConnectionFactory GetConnectionFactory(string connectionString, string hostName, string userName, string password, int port, bool ssl, bool insecureSsl)
+        internal static ConnectionFactory GetConnectionFactory(string connectionString, string hostName, string userName, string password, int port, bool enableSsl, bool skipCertificateValidation)
         {
             ConnectionFactory connectionFactory = new ConnectionFactory();
 
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             {
                 Uri amqpUri = new Uri(connectionString);
                 connectionFactory.Uri = amqpUri;
-                ConfigureSsl(connectionFactory, amqpUri.Host, ssl, insecureSsl);
+                ConfigureSsl(connectionFactory, amqpUri.Host, enableSsl, skipCertificateValidation);
             }
             else
             {
@@ -96,15 +96,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                     connectionFactory.Port = port;
                 }
 
-                ConfigureSsl(connectionFactory, hostName, ssl, insecureSsl);
+                ConfigureSsl(connectionFactory, hostName, enableSsl, skipCertificateValidation);
             }
 
             return connectionFactory;
         }
 
-        internal static void ConfigureSsl(ConnectionFactory connectionFactory, string hostname, bool ssl, bool insecureSsl)
+        internal static void ConfigureSsl(ConnectionFactory connectionFactory, string hostname, bool enableSsl, bool skipCertificateValidation)
         {
-            if (ssl)
+            if (enableSsl)
             {
                 connectionFactory.Ssl = new SslOption
                 {
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                     // Set SNI in order to work for multiple RabbitMQ clusters located behind a LoadBalancer
                     ServerName = hostname,
                 };
-                if (insecureSsl)
+                if (skipCertificateValidation)
                 {
                     connectionFactory.Ssl.AcceptablePolicyErrors =
                         SslPolicyErrors.RemoteCertificateNameMismatch | SslPolicyErrors.RemoteCertificateChainErrors;

--- a/src/Services/RabbitMQService.cs
+++ b/src/Services/RabbitMQService.cs
@@ -74,6 +74,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                     connectionFactory.Ssl = new SslOption
                     {
                         Enabled = true,
+                        // Set SNI in order to work for multiple RabbitMQ clusters located behind a LoadBalancer
                         ServerName = amqpUri.Host,
                     };
                 }
@@ -105,6 +106,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                     connectionFactory.Ssl = new SslOption
                     {
                         Enabled = true,
+                        // Set SNI in order to work for multiple RabbitMQ clusters located behind a LoadBalancer
                         ServerName = hostName,
                     };
                 }

--- a/src/Services/RabbitMQService.cs
+++ b/src/Services/RabbitMQService.cs
@@ -97,7 +97,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 }
 
                 ConfigureSsl(connectionFactory, hostName, ssl, insecureSsl);
-
             }
 
             return connectionFactory;

--- a/src/Services/RabbitMQService.cs
+++ b/src/Services/RabbitMQService.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                     connectionFactory.Ssl = new SslOption
                     {
                         Enabled = true,
-                        ServerName = amqpUri.Host
+                        ServerName = amqpUri.Host,
                     };
                 }
             }
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                     connectionFactory.Ssl = new SslOption
                     {
                         Enabled = true,
-                        ServerName = hostName
+                        ServerName = hostName,
                     };
                 }
             }

--- a/src/Services/RabbitMQService.cs
+++ b/src/Services/RabbitMQService.cs
@@ -16,26 +16,28 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         private readonly string _userName;
         private readonly string _password;
         private readonly int _port;
+        private readonly bool _ssl;
         private readonly object _publishBatchLock;
 
         private IBasicPublishBatch _batch;
 
-        public RabbitMQService(string connectionString, string hostName, string userName, string password, int port)
+        public RabbitMQService(string connectionString, string hostName, string userName, string password, int port, bool ssl)
         {
             _connectionString = connectionString;
             _hostName = hostName;
             _userName = userName;
             _password = password;
             _port = port;
+            _ssl = ssl;
 
-            ConnectionFactory connectionFactory = GetConnectionFactory(_connectionString, _hostName, _userName, _password, _port);
+            ConnectionFactory connectionFactory = GetConnectionFactory(_connectionString, _hostName, _userName, _password, _port, _ssl);
 
             _model = connectionFactory.CreateConnection().CreateModel();
             _publishBatchLock = new object();
         }
 
-        public RabbitMQService(string connectionString, string hostName, string queueName, string userName, string password, int port)
-            : this(connectionString, hostName, userName, password, port)
+        public RabbitMQService(string connectionString, string hostName, string queueName, string userName, string password, int port, bool ssl)
+            : this(connectionString, hostName, userName, password, port, ssl)
         {
             _rabbitMQModel = new RabbitMQModel(_model);
             _queueName = queueName ?? throw new ArgumentNullException(nameof(queueName));
@@ -58,14 +60,23 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             _batch = _model.CreateBasicPublishBatch();
         }
 
-        internal static ConnectionFactory GetConnectionFactory(string connectionString, string hostName, string userName, string password, int port)
+        internal static ConnectionFactory GetConnectionFactory(string connectionString, string hostName, string userName, string password, int port, bool ssl)
         {
             ConnectionFactory connectionFactory = new ConnectionFactory();
 
             // Only set these if specified by user. Otherwise, API will use default parameters.
             if (!string.IsNullOrEmpty(connectionString))
             {
-                connectionFactory.Uri = new Uri(connectionString);
+                amqpUri = new Uri(connectionString);
+                connectionFactory.Uri = amqpUri;
+                if (ssl)
+                {
+                    connectionFactory.Ssl = new SslOption
+                    {
+                        Enabled = true,
+                        ServerName = amqpUri.Host
+                    };
+                }
             }
             else
             {
@@ -87,6 +98,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 if (port != 0)
                 {
                     connectionFactory.Port = port;
+                }
+
+                if (ssl)
+                {
+                    connectionFactory.Ssl = new SslOption
+                    {
+                        Enabled = true,
+                        ServerName = hostName
+                    };
                 }
             }
 

--- a/src/Trigger/RabbitMQTriggerAttribute.cs
+++ b/src/Trigger/RabbitMQTriggerAttribute.cs
@@ -67,5 +67,10 @@ namespace Microsoft.Azure.WebJobs
         /// Enable or disable ssl in RabbitMQ connection.
         /// </summary>
         public bool Ssl { get; set; }
+
+        /// <summary>
+        /// Enable os disable checking certificate when Ssl is enabled (not recommended for production).
+        /// </summary>
+        public bool InsecureSsl { get; set; }
     }
 }

--- a/src/Trigger/RabbitMQTriggerAttribute.cs
+++ b/src/Trigger/RabbitMQTriggerAttribute.cs
@@ -9,18 +9,20 @@ namespace Microsoft.Azure.WebJobs
     [Binding]
     public sealed class RabbitMQTriggerAttribute : Attribute
     {
-        public RabbitMQTriggerAttribute(string queueName)
+        public RabbitMQTriggerAttribute(string queueName, bool ssl)
         {
             QueueName = queueName;
+            Ssl = ssl;
         }
 
-        public RabbitMQTriggerAttribute(string hostName, string userNameSetting, string passwordSetting, int port, string queueName)
+        public RabbitMQTriggerAttribute(string hostName, string userNameSetting, string passwordSetting, int port, string queueName, bool ssl)
         {
             HostName = hostName;
             UserNameSetting = userNameSetting;
             PasswordSetting = passwordSetting;
             Port = port;
             QueueName = queueName;
+            Ssl = ssl;
         }
 
         /// <summary>

--- a/src/Trigger/RabbitMQTriggerAttribute.cs
+++ b/src/Trigger/RabbitMQTriggerAttribute.cs
@@ -9,20 +9,18 @@ namespace Microsoft.Azure.WebJobs
     [Binding]
     public sealed class RabbitMQTriggerAttribute : Attribute
     {
-        public RabbitMQTriggerAttribute(string queueName, bool ssl)
+        public RabbitMQTriggerAttribute(string queueName)
         {
             QueueName = queueName;
-            Ssl = ssl;
         }
 
-        public RabbitMQTriggerAttribute(string hostName, string userNameSetting, string passwordSetting, int port, string queueName, bool ssl)
+        public RabbitMQTriggerAttribute(string hostName, string userNameSetting, string passwordSetting, int port, string queueName)
         {
             HostName = hostName;
             UserNameSetting = userNameSetting;
             PasswordSetting = passwordSetting;
             Port = port;
             QueueName = queueName;
-            Ssl = ssl;
         }
 
         /// <summary>

--- a/src/Trigger/RabbitMQTriggerAttribute.cs
+++ b/src/Trigger/RabbitMQTriggerAttribute.cs
@@ -60,5 +60,10 @@ namespace Microsoft.Azure.WebJobs
         /// Gets or sets the Port used. Defaults to 0.
         /// </summary>
         public int Port { get; set; }
+
+        /// <summary>
+        /// Enable or disable ssl in RabbitMQ connection.
+        /// </summary>
+        public bool Ssl { get; set; }
     }
 }

--- a/src/Trigger/RabbitMQTriggerAttribute.cs
+++ b/src/Trigger/RabbitMQTriggerAttribute.cs
@@ -64,11 +64,11 @@ namespace Microsoft.Azure.WebJobs
         /// <summary>
         /// Enable or disable ssl in RabbitMQ connection.
         /// </summary>
-        public bool Ssl { get; set; }
+        public bool EnableSsl { get; set; }
 
         /// <summary>
         /// Enable os disable checking certificate when Ssl is enabled (not recommended for production).
         /// </summary>
-        public bool InsecureSsl { get; set; }
+        public bool SkipCertificateValidation { get; set; }
     }
 }

--- a/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
+++ b/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
@@ -59,9 +59,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
             string password = Resolve(attribute.PasswordSetting);
 
-            bool ssl = attribute.Ssl;
+            bool enableSsl = attribute.EnableSsl;
 
-            bool insecureSsl = attribute.InsecureSsl;
+            bool skipCertificateValidation = attribute.SkipCertificateValidation;
 
             int port = attribute.Port;
 
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 throw new InvalidOperationException("RabbitMQ username and password required if not connecting to localhost");
             }
 
-            IRabbitMQService service = _provider.GetService(connectionString, hostName, queueName, userName, password, port, ssl, insecureSsl);
+            IRabbitMQService service = _provider.GetService(connectionString, hostName, queueName, userName, password, port, enableSsl, skipCertificateValidation);
 
             return Task.FromResult<ITriggerBinding>(new RabbitMQTriggerBinding(service, hostName, queueName, _logger, parameter.ParameterType, _options.Value.PrefetchCount));
         }

--- a/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
+++ b/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
             string password = Resolve(attribute.PasswordSetting);
 
-            bool ssl = Resolve(attribute.Ssl);
+            bool ssl = attribute.Ssl;
 
             int port = attribute.Port;
 

--- a/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
+++ b/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
@@ -61,6 +61,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
             bool ssl = attribute.Ssl;
 
+            bool insecureSsl = attribute.InsecureSsl;
+
             int port = attribute.Port;
 
             if (string.IsNullOrEmpty(connectionString) && !Utility.ValidateUserNamePassword(userName, password, hostName))
@@ -68,7 +70,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 throw new InvalidOperationException("RabbitMQ username and password required if not connecting to localhost");
             }
 
-            IRabbitMQService service = _provider.GetService(connectionString, hostName, queueName, userName, password, port, ssl);
+            IRabbitMQService service = _provider.GetService(connectionString, hostName, queueName, userName, password, port, ssl, insecureSsl);
 
             return Task.FromResult<ITriggerBinding>(new RabbitMQTriggerBinding(service, hostName, queueName, _logger, parameter.ParameterType, _options.Value.PrefetchCount));
         }

--- a/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
+++ b/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
@@ -59,6 +59,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
             string password = Resolve(attribute.PasswordSetting);
 
+            bool ssl = Resolve(attribute.Ssl);
+
             int port = attribute.Port;
 
             if (string.IsNullOrEmpty(connectionString) && !Utility.ValidateUserNamePassword(userName, password, hostName))
@@ -66,7 +68,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 throw new InvalidOperationException("RabbitMQ username and password required if not connecting to localhost");
             }
 
-            IRabbitMQService service = _provider.GetService(connectionString, hostName, queueName, userName, password, port);
+            IRabbitMQService service = _provider.GetService(connectionString, hostName, queueName, userName, password, port, ssl);
 
             return Task.FromResult<ITriggerBinding>(new RabbitMQTriggerBinding(service, hostName, queueName, _logger, parameter.ParameterType, _options.Value.PrefetchCount));
         }

--- a/src/Utility.cs
+++ b/src/Utility.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Extensions
                 }
 
                 return false;
-            });            
+            });
         }
 
         internal static bool ValidateUserNamePassword(string userName, string password, string hostName)

--- a/src/Utility.cs
+++ b/src/Utility.cs
@@ -28,6 +28,19 @@ namespace Microsoft.Azure.WebJobs.Extensions
             });
         }
 
+        internal static bool FirstOrDefault(params bool[] values)
+        {
+            return values.FirstOrDefault(v =>
+            {
+                if (v)
+                {
+                    return true;
+                }
+
+                return false;
+            });            
+        }
+
         internal static bool ValidateUserNamePassword(string userName, string password, string hostName)
         {
             if (!hostName.Equals(Constants.LocalHost, StringComparison.InvariantCultureIgnoreCase) && (string.IsNullOrEmpty(userName) || string.IsNullOrEmpty(password)))

--- a/src/Utility.cs
+++ b/src/Utility.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Azure.WebJobs.Extensions
         internal static bool FirstOrDefault(params bool[] values)
         {
             return values.FirstOrDefault(v => v);
+        }
 
         internal static bool ValidateUserNamePassword(string userName, string password, string hostName)
         {

--- a/src/Utility.cs
+++ b/src/Utility.cs
@@ -17,29 +17,12 @@ namespace Microsoft.Azure.WebJobs.Extensions
 
         internal static int FirstOrDefault(params int[] values)
         {
-            return values.FirstOrDefault(v =>
-            {
-                if (v != 0)
-                {
-                    return true;
-                }
-
-                return false;
-            });
+            return values.FirstOrDefault(v => v != 0);
         }
 
         internal static bool FirstOrDefault(params bool[] values)
         {
-            return values.FirstOrDefault(v =>
-            {
-                if (v)
-                {
-                    return true;
-                }
-
-                return false;
-            });
-        }
+            return values.FirstOrDefault(v => v);
 
         internal static bool ValidateUserNamePassword(string userName, string password, string hostName)
         {

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQClientBuilderTests.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQClientBuilderTests.cs
@@ -23,13 +23,13 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
             var options = new OptionsWrapper<RabbitMQOptions>(new RabbitMQOptions { HostName = Constants.LocalHost });
             var mockServiceFactory = new Mock<IRabbitMQServiceFactory>();
             var config = new RabbitMQExtensionConfigProvider(options, new Mock<INameResolver>().Object, mockServiceFactory.Object, new LoggerFactory(), _emptyConfig);
-            mockServiceFactory.Setup(m => m.CreateService(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>())).Returns(new Mock<IRabbitMQService>().Object);
+            mockServiceFactory.Setup(m => m.CreateService(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), false, false)).Returns(new Mock<IRabbitMQService>().Object);
             RabbitMQAttribute attr = GetTestAttribute();
 
             RabbitMQClientBuilder clientBuilder = new RabbitMQClientBuilder(config, options);
             var model = clientBuilder.Convert(attr);
 
-            mockServiceFactory.Verify(m => m.CreateService(It.IsAny<string>(), Constants.LocalHost, "guest", "guest", 5672), Times.Exactly(1));
+            mockServiceFactory.Verify(m => m.CreateService(It.IsAny<string>(), Constants.LocalHost, "guest", "guest", 5672, false, false), Times.Exactly(1));
         }
 
         [Fact]
@@ -37,7 +37,7 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
         {
             var options = new OptionsWrapper<RabbitMQOptions>(new RabbitMQOptions { HostName = Constants.LocalHost });
             var mockServiceFactory = new Mock<IRabbitMQServiceFactory>();
-            mockServiceFactory.SetupSequence(m => m.CreateService(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()))
+            mockServiceFactory.SetupSequence(m => m.CreateService(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), false, false))
                 .Returns(GetRabbitMQService())
                 .Returns(GetRabbitMQService());
             var config = new RabbitMQExtensionConfigProvider(options, new Mock<INameResolver>().Object, mockServiceFactory.Object, new LoggerFactory(), _emptyConfig);

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQExtensionConfigProviderTests.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQExtensionConfigProviderTests.cs
@@ -26,7 +26,9 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
                It.IsAny<string>(),
                It.IsAny<string>(),
                It.IsAny<string>(),
-               It.IsAny<int>())).Returns(new Mock<IRabbitMQService>().Object)
+               It.IsAny<int>(),
+               false,
+               false)).Returns(new Mock<IRabbitMQService>().Object)
                .Returns(new Mock<IRabbitMQService>().Object)
                .Returns(new Mock<IRabbitMQService>().Object)
                .Returns(new Mock<IRabbitMQService>().Object);
@@ -36,7 +38,9 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
                It.IsAny<string>(),
                It.IsAny<string>(),
                It.IsAny<string>(),
-               It.IsAny<int>())).Returns(new Mock<IRabbitMQService>().Object)
+               It.IsAny<int>(),
+               false,
+               false)).Returns(new Mock<IRabbitMQService>().Object)
                .Returns(new Mock<IRabbitMQService>().Object)
                .Returns(new Mock<IRabbitMQService>().Object)
                .Returns(new Mock<IRabbitMQService>().Object);
@@ -48,9 +52,9 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
                 NullLoggerFactory.Instance,
                 new Mock<IConfiguration>().Object);
 
-            var rabbitmqService1 = extensionConfigProvider.GetService("something", "something", "something", "something", 80);
-            var rabbitmqService2 = extensionConfigProvider.GetService("something", "something", "something", "something", 80);
-            var rabbitmqService3 = extensionConfigProvider.GetService("somethingElse", "something", "something", "something", 80);
+            var rabbitmqService1 = extensionConfigProvider.GetService("something", "something", "something", "something", 80, false, false);
+            var rabbitmqService2 = extensionConfigProvider.GetService("something", "something", "something", "something", 80, false, false);
+            var rabbitmqService3 = extensionConfigProvider.GetService("somethingElse", "something", "something", "something", 80, false, false);
 
             // 1 and 2 should be equal
             Assert.Equal(rabbitmqService1, rabbitmqService2);
@@ -59,9 +63,9 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
             Assert.NotEqual(rabbitmqService1, rabbitmqService3);
             Assert.NotEqual(rabbitmqService2, rabbitmqService3);
 
-            var rabbitmqService4 = extensionConfigProvider.GetService("asomething", "asomething", "asomething", "asomething", "asomething", 80);
-            var rabbitmqService5 = extensionConfigProvider.GetService("asomething", "asomething", "asomething", "asomething", "asomething", 80);
-            var rabbitmqService6 = extensionConfigProvider.GetService("asomethingElse", "asomething", "asomething", "asomething", "asomething", 80);
+            var rabbitmqService4 = extensionConfigProvider.GetService("asomething", "asomething", "asomething", "asomething", "asomething", 80, false, false);
+            var rabbitmqService5 = extensionConfigProvider.GetService("asomething", "asomething", "asomething", "asomething", "asomething", 80, false, false);
+            var rabbitmqService6 = extensionConfigProvider.GetService("asomethingElse", "asomething", "asomething", "asomething", "asomething", 80, false, false);
 
             // 4 and 5 should be equal
             Assert.Equal(rabbitmqService4, rabbitmqService5);

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQServiceTests.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQServiceTests.cs
@@ -17,7 +17,7 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
         public void Handles_Connection_Attributes_And_Options(string connectionString, string hostName, string userName, string password, int port,
             string expectedConnectionString, string expectedHostName, string expectedUserName, string expectedPassword, int expectedPort)
         {
-            ConnectionFactory factory = RabbitMQService.GetConnectionFactory(connectionString, hostName, userName, password, port);
+            ConnectionFactory factory = RabbitMQService.GetConnectionFactory(connectionString, hostName, userName, password, port, false, false);
 
             if (String.IsNullOrEmpty(connectionString))
             {


### PR DESCRIPTION
In order to connect to an AMQPS endpoint a new attribute is necessary to configure 'SslOption' for 'ConnectionFactory'.
Furthermore, to allow using self-signed certificates for development environments another attribute has been introduced: 'InsecureSsl'.
By default, SslOption does NOT enable SNI extension (https://en.wikipedia.org/wiki/Server_Name_Indication). To enable it, setting the property 'ServerName' is enough. This extension is mandatory to allow connecting to several RabbitMQ clusters behind a load balancer.