### PR TITLE
Add new parameter to specify the vhost to use on RabbitMQ server.

### DIFF
--- a/binding-library/java/release_notes.md
+++ b/binding-library/java/release_notes.md
@@ -1,1 +1,3 @@
 ### Release notes
+
+- Add a new `VirtualHost` parameter to `RabbitMQTrigger`, `RabbitMQOutput` to allow to choose which [Virtual Hosts](https://www.rabbitmq.com/vhosts.html) to use when using host/user/password authentication method.

--- a/binding-library/java/src/main/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQOutput.java
+++ b/binding-library/java/src/main/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQOutput.java
@@ -76,6 +76,13 @@ public @interface RabbitMQOutput {
     String password() default "";
 
     /**
+     * The VirtualHost used on the rabbitMQ Server.
+     * @see <a href="https://www.rabbitmq.com/vhosts.html">Virtual Hosts</a>
+     * @return The VirtualHost used on the rabbitMQ Server.
+     */
+    String virtualHost() default "";
+
+    /**
      * The port to attach.
      * @return The port to attach.
      */

--- a/binding-library/java/src/main/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQTrigger.java
+++ b/binding-library/java/src/main/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQTrigger.java
@@ -72,6 +72,13 @@ public @interface RabbitMQTrigger {
     String passwordSetting() default "";
 
     /**
+     * The VirtualHost used on the rabbitMQ Server.
+     * @see <a href="https://www.rabbitmq.com/vhosts.html">Virtual Hosts</a>
+     * @return The VirtualHost used on the rabbitMQ Server.
+     */
+    String virtualHostSetting() default "";
+
+    /**
      * The port to attach.
      * @return The port to attach.
      */

--- a/binding-library/java/test/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQOutputTests.java
+++ b/binding-library/java/test/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQOutputTests.java
@@ -19,6 +19,7 @@ public class RabbitMQOutputTests {
         EasyMock.expect(outputInterface.password()).andReturn("randomPassword");
         EasyMock.expect(outputInterface.queueName()).andReturn("randomQueueName");
         EasyMock.expect(outputInterface.userName()).andReturn("randomUserName");
+        EasyMock.expect(outputInterface.virtualHost()).andReturn("randomVirtualHost");
         EasyMock.expect(outputInterface.connectionStringSetting()).andReturn("randomConnectionStringSetting");
         EasyMock.expect(outputInterface.port()).andReturn(123);
 

--- a/binding-library/java/test/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQTriggerTests.java
+++ b/binding-library/java/test/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQTriggerTests.java
@@ -19,6 +19,7 @@ public class RabbitMQTriggerTests {
         EasyMock.expect(triggerInterface.passwordSetting()).andReturn("randomPassword");
         EasyMock.expect(triggerInterface.queueName()).andReturn("randomQueueName");
         EasyMock.expect(triggerInterface.userNameSetting()).andReturn("randomUserName");
+        EasyMock.expect(triggerInterface.virtualHost()).andReturn("randomVirtualHost");
         EasyMock.expect(triggerInterface.connectionStringSetting()).andReturn("randomConnectionStringSetting");
         EasyMock.expect(triggerInterface.port()).andReturn(123);
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,4 @@
 ### Release notes
 
 # Added pooling for RabbitMQService
+- Add a new `VirtualHost` parameter to `[RabbitMQTrigger]`, `[RabbitMQ]` and `RabbitMQOptions` to allow to choose which [Virtual Hosts](https://www.rabbitmq.com/vhosts.html) to use when using host/user/password authentication method.

--- a/src/Bindings/RabbitMQClientBuilder.cs
+++ b/src/Bindings/RabbitMQClientBuilder.cs
@@ -35,8 +35,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             string resolvedUserName = Utility.FirstOrDefault(attribute.UserName, _options.Value.UserName);
             string resolvedPassword = Utility.FirstOrDefault(attribute.Password, _options.Value.Password);
             int resolvedPort = Utility.FirstOrDefault(attribute.Port, _options.Value.Port);
+            string resolvedVirtualHost = Utility.FirstOrDefault(attribute.VirtualHost, _options.Value.VirtualHost);
 
-            IRabbitMQService service = _configProvider.GetService(resolvedConnectionString, resolvedHostName, resolvedUserName, resolvedPassword, resolvedPort);
+            IRabbitMQService service = _configProvider.GetService(resolvedConnectionString, resolvedHostName, resolvedUserName, resolvedPassword, resolvedPort, resolvedVirtualHost);
 
             return service.Model;
         }

--- a/src/Config/DefaultRabbitMQServiceFactory.cs
+++ b/src/Config/DefaultRabbitMQServiceFactory.cs
@@ -5,14 +5,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     internal class DefaultRabbitMQServiceFactory : IRabbitMQServiceFactory
     {
-        public IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port)
+        public IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port, string virtualHost)
         {
-            return new RabbitMQService(connectionString, hostName, queueName, userName, password, port);
+            return new RabbitMQService(connectionString, hostName, queueName, userName, password, port, virtualHost);
         }
 
-        public IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port)
+        public IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port, string virtualHost)
         {
-            return new RabbitMQService(connectionString, hostName, userName, password, port);
+            return new RabbitMQService(connectionString, hostName, userName, password, port, virtualHost);
         }
     }
 }

--- a/src/Config/IRabbitMQServiceFactory.cs
+++ b/src/Config/IRabbitMQServiceFactory.cs
@@ -5,8 +5,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     public interface IRabbitMQServiceFactory
     {
-        IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port);
+        IRabbitMQService CreateService(string connectionString, string hostName, string queueName, string userName, string password, int port, string virtualHost);
 
-        IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port);
+        IRabbitMQService CreateService(string connectionString, string hostName, string userName, string password, int port, string virtualHost);
     }
 }

--- a/src/Config/RabbitMQExtensionConfigProvider.cs
+++ b/src/Config/RabbitMQExtensionConfigProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -87,6 +87,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             string userName = Utility.FirstOrDefault(attribute.UserName, _options.Value.UserName);
             string password = Utility.FirstOrDefault(attribute.Password, _options.Value.Password);
             int port = Utility.FirstOrDefault(attribute.Port, _options.Value.Port);
+            string virtualHost = Utility.FirstOrDefault(attribute.VirtualHost, _options.Value.VirtualHost);
 
             RabbitMQAttribute resolvedAttribute;
             IRabbitMQService service;
@@ -99,9 +100,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 UserName = userName,
                 Password = password,
                 Port = port,
+                VirtualHost = virtualHost,
             };
 
-            service = GetService(connectionString, hostName, queueName, userName, password, port);
+            service = GetService(connectionString, hostName, queueName, userName, password, port, virtualHost);
 
             return new RabbitMQContext
             {
@@ -110,19 +112,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             };
         }
 
-        internal IRabbitMQService GetService(string connectionString, string hostName, string queueName, string userName, string password, int port)
+        internal IRabbitMQService GetService(string connectionString, string hostName, string queueName, string userName, string password, int port, string virtualHost)
         {
-            string[] keyArray = { connectionString, hostName, queueName, userName, password, port.ToString() };
+            string[] keyArray = { connectionString, hostName, queueName, userName, password, port.ToString(), virtualHost };
             string key = string.Join(",", keyArray);
-            return _connectionParametersToService.GetOrAdd(key, _ => _rabbitMQServiceFactory.CreateService(connectionString, hostName, queueName, userName, password, port));
+            return _connectionParametersToService.GetOrAdd(key, _ => _rabbitMQServiceFactory.CreateService(connectionString, hostName, queueName, userName, password, port, virtualHost));
         }
 
         // Overloaded method used only for getting the RabbitMQ client
-        internal IRabbitMQService GetService(string connectionString, string hostName, string userName, string password, int port)
+        internal IRabbitMQService GetService(string connectionString, string hostName, string userName, string password, int port, string virtualHost)
         {
-            string[] keyArray = { connectionString, hostName, userName, password, port.ToString() };
+            string[] keyArray = { connectionString, hostName, userName, password, port.ToString(), virtualHost };
             string key = string.Join(",", keyArray);
-            return _connectionParametersToService.GetOrAdd(key, _ => _rabbitMQServiceFactory.CreateService(connectionString, hostName, userName, password, port));
+            return _connectionParametersToService.GetOrAdd(key, _ => _rabbitMQServiceFactory.CreateService(connectionString, hostName, userName, password, port, virtualHost));
         }
     }
 }

--- a/src/Config/RabbitMQOptions.cs
+++ b/src/Config/RabbitMQOptions.cs
@@ -38,6 +38,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         public string Password { get; set; }
 
         /// <summary>
+        /// Gets or sets the VirtualHost used on the RabbitMQ Server.
+        /// <see href="https://www.rabbitmq.com/vhosts.html" />.
+        /// </summary>
+        public string VirtualHost { get; set; }
+
+        /// <summary>
         /// Gets or sets the ConnectionString used to authenticate with RabbitMQ.
         /// </summary>
         public string ConnectionString { get; set; }
@@ -59,6 +65,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 { nameof(HostName), HostName },
                 { nameof(QueueName), QueueName },
                 { nameof(Port), Port },
+                { nameof(VirtualHost), VirtualHost },
                 { nameof(PrefetchCount), PrefetchCount },
             };
 

--- a/src/RabbitMQAttribute.cs
+++ b/src/RabbitMQAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -46,6 +46,13 @@ namespace Microsoft.Azure.WebJobs
         /// Gets or sets the Port used. Defaults to 0.
         /// </summary>
         public int Port { get; set; }
+
+        /// <summary>
+        /// Gets or sets the vhost to use when connecting to RabbitMQ using HostName / UserName / Password
+        /// <see href="https://www.rabbitmq.com/vhosts.html"/>.
+        /// </summary>
+        [AppSetting]
+        public string VirtualHost { get; set; }
 
         /// <summary>
         /// Gets or sets the name of app setting that contains the connection string to authenticate with RabbitMQ.

--- a/src/Services/RabbitMQService.cs
+++ b/src/Services/RabbitMQService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -15,27 +15,29 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         private readonly string _queueName;
         private readonly string _userName;
         private readonly string _password;
+        private readonly string _virtualHost;
         private readonly int _port;
         private readonly object _publishBatchLock;
 
         private IBasicPublishBatch _batch;
 
-        public RabbitMQService(string connectionString, string hostName, string userName, string password, int port)
+        public RabbitMQService(string connectionString, string hostName, string userName, string password, int port, string virtualHost)
         {
             _connectionString = connectionString;
             _hostName = hostName;
             _userName = userName;
             _password = password;
             _port = port;
+            _virtualHost = virtualHost;
 
-            ConnectionFactory connectionFactory = GetConnectionFactory(_connectionString, _hostName, _userName, _password, _port);
+            ConnectionFactory connectionFactory = GetConnectionFactory(_connectionString, _hostName, _userName, _password, _port, _virtualHost);
 
             _model = connectionFactory.CreateConnection().CreateModel();
             _publishBatchLock = new object();
         }
 
-        public RabbitMQService(string connectionString, string hostName, string queueName, string userName, string password, int port)
-            : this(connectionString, hostName, userName, password, port)
+        public RabbitMQService(string connectionString, string hostName, string queueName, string userName, string password, int port, string virtualHost)
+            : this(connectionString, hostName, userName, password, port, virtualHost)
         {
             _rabbitMQModel = new RabbitMQModel(_model);
             _queueName = queueName ?? throw new ArgumentNullException(nameof(queueName));
@@ -58,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             _batch = _model.CreateBasicPublishBatch();
         }
 
-        internal static ConnectionFactory GetConnectionFactory(string connectionString, string hostName, string userName, string password, int port)
+        internal static ConnectionFactory GetConnectionFactory(string connectionString, string hostName, string userName, string password, int port, string virtualHost)
         {
             ConnectionFactory connectionFactory = new ConnectionFactory();
 
@@ -82,6 +84,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 if (!string.IsNullOrEmpty(password))
                 {
                     connectionFactory.Password = password;
+                }
+
+                if (!string.IsNullOrEmpty(virtualHost))
+                {
+                    connectionFactory.VirtualHost = virtualHost;
                 }
 
                 if (port != 0)

--- a/src/Trigger/RabbitMQTriggerAttribute.cs
+++ b/src/Trigger/RabbitMQTriggerAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -60,5 +60,11 @@ namespace Microsoft.Azure.WebJobs
         /// Gets or sets the Port used. Defaults to 0.
         /// </summary>
         public int Port { get; set; }
+
+        /// <summary>
+        /// Gets or sets the vhost to use when connecting to RabbitMQ using HostName / UserName / Password
+        /// <see href="https://www.rabbitmq.com/vhosts.html"/>.
+        /// </summary>
+        public string VirtualHost { get; set; }
     }
 }

--- a/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
+++ b/src/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
@@ -59,6 +59,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
             string password = Resolve(attribute.PasswordSetting);
 
+            string virtualHost = Resolve(attribute.VirtualHost);
+
             int port = attribute.Port;
 
             if (string.IsNullOrEmpty(connectionString) && !Utility.ValidateUserNamePassword(userName, password, hostName))
@@ -66,7 +68,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 throw new InvalidOperationException("RabbitMQ username and password required if not connecting to localhost");
             }
 
-            IRabbitMQService service = _provider.GetService(connectionString, hostName, queueName, userName, password, port);
+            IRabbitMQService service = _provider.GetService(connectionString, hostName, queueName, userName, password, port, virtualHost);
 
             return Task.FromResult<ITriggerBinding>(new RabbitMQTriggerBinding(service, hostName, queueName, _logger, parameter.ParameterType, _options.Value.PrefetchCount));
         }

--- a/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
@@ -129,6 +129,14 @@ namespace WebJobs.Extensions.RabbitMQ.Samples
             logger.LogInformation($"RabbitMQ output binding function sent message: {outputMessage}");
         }
 
+        public static void RabbitMQTrigger_String_NoConnectionString_WithVirtualHost(
+            [RabbitMQTrigger(hostName: "%RabbitMQHostName%", userNameSetting: "%UserNameSetting%", passwordSetting: "%PasswordSetting%", port: 5672, queueName: "queue-in-vhost", VirtualHost = "azure-rabbitmq-vhost")] string message,
+            string consumerTag,
+            ILogger logger)
+        {
+            logger.LogInformation($"RabbitMQ queue trigger function processed message: {message} and consumer tag: {consumerTag}");
+        }
+
         public class TestClass
         {
             private readonly int _x;

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQClientBuilderTests.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQClientBuilderTests.cs
@@ -1,8 +1,7 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using Microsoft.Azure.WebJobs;
-using Microsoft.Azure.WebJobs.Extensions;
 using Microsoft.Azure.WebJobs.Extensions.RabbitMQ;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -24,13 +23,13 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
             var options = new OptionsWrapper<RabbitMQOptions>(new RabbitMQOptions { HostName = Constants.LocalHost });
             var mockServiceFactory = new Mock<IRabbitMQServiceFactory>();
             var config = new RabbitMQExtensionConfigProvider(options, new Mock<INameResolver>().Object, mockServiceFactory.Object, new LoggerFactory(), _emptyConfig);
-            mockServiceFactory.Setup(m => m.CreateService(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>())).Returns(new Mock<IRabbitMQService>().Object);
+            mockServiceFactory.Setup(m => m.CreateService(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>())).Returns(new Mock<IRabbitMQService>().Object);
             RabbitMQAttribute attr = GetTestAttribute();
 
             RabbitMQClientBuilder clientBuilder = new RabbitMQClientBuilder(config, options);
             var model = clientBuilder.Convert(attr);
 
-            mockServiceFactory.Verify(m => m.CreateService(It.IsAny<string>(), Constants.LocalHost, "guest", "guest", 5672), Times.Exactly(1));
+            mockServiceFactory.Verify(m => m.CreateService(It.IsAny<string>(), Constants.LocalHost, "guest", "guest", 5672, "vhost"), Times.Exactly(1));
         }
 
         [Fact]
@@ -38,7 +37,7 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
         {
             var options = new OptionsWrapper<RabbitMQOptions>(new RabbitMQOptions { HostName = Constants.LocalHost });
             var mockServiceFactory = new Mock<IRabbitMQServiceFactory>();
-            mockServiceFactory.SetupSequence(m => m.CreateService(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()))
+            mockServiceFactory.SetupSequence(m => m.CreateService(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()))
                 .Returns(GetRabbitMQService())
                 .Returns(GetRabbitMQService());
             var config = new RabbitMQExtensionConfigProvider(options, new Mock<INameResolver>().Object, mockServiceFactory.Object, new LoggerFactory(), _emptyConfig);
@@ -60,7 +59,8 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
                 HostName = Constants.LocalHost,
                 UserName = "guest",
                 Password = "guest",
-                Port = 5672
+                Port = 5672,
+                VirtualHost = "vhost"
             };
         }
 

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQExtensionConfigProviderTests.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQExtensionConfigProviderTests.cs
@@ -26,7 +26,8 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
                It.IsAny<string>(),
                It.IsAny<string>(),
                It.IsAny<string>(),
-               It.IsAny<int>())).Returns(new Mock<IRabbitMQService>().Object)
+               It.IsAny<int>(),
+               It.IsAny<string>())).Returns(new Mock<IRabbitMQService>().Object)
                .Returns(new Mock<IRabbitMQService>().Object)
                .Returns(new Mock<IRabbitMQService>().Object)
                .Returns(new Mock<IRabbitMQService>().Object);
@@ -36,7 +37,8 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
                It.IsAny<string>(),
                It.IsAny<string>(),
                It.IsAny<string>(),
-               It.IsAny<int>())).Returns(new Mock<IRabbitMQService>().Object)
+               It.IsAny<int>(),
+               It.IsAny<string>())).Returns(new Mock<IRabbitMQService>().Object)
                .Returns(new Mock<IRabbitMQService>().Object)
                .Returns(new Mock<IRabbitMQService>().Object)
                .Returns(new Mock<IRabbitMQService>().Object);
@@ -48,9 +50,9 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
                 NullLoggerFactory.Instance,
                 new Mock<IConfiguration>().Object);
 
-            var rabbitmqService1 = extensionConfigProvider.GetService("something", "something", "something", "something", 80);
-            var rabbitmqService2 = extensionConfigProvider.GetService("something", "something", "something", "something", 80);
-            var rabbitmqService3 = extensionConfigProvider.GetService("somethingElse", "something", "something", "something", 80);
+            var rabbitmqService1 = extensionConfigProvider.GetService("something", "something", "something", "something", 80, "vhost");
+            var rabbitmqService2 = extensionConfigProvider.GetService("something", "something", "something", "something", 80, "vhost");
+            var rabbitmqService3 = extensionConfigProvider.GetService("somethingElse", "something", "something", "something", 80, "vhost");
 
             // 1 and 2 should be equal
             Assert.Equal(rabbitmqService1, rabbitmqService2);
@@ -59,9 +61,9 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
             Assert.NotEqual(rabbitmqService1, rabbitmqService3);
             Assert.NotEqual(rabbitmqService2, rabbitmqService3);
 
-            var rabbitmqService4 = extensionConfigProvider.GetService("asomething", "asomething", "asomething", "asomething", "asomething", 80);
-            var rabbitmqService5 = extensionConfigProvider.GetService("asomething", "asomething", "asomething", "asomething", "asomething", 80);
-            var rabbitmqService6 = extensionConfigProvider.GetService("asomethingElse", "asomething", "asomething", "asomething", "asomething", 80);
+            var rabbitmqService4 = extensionConfigProvider.GetService("asomething", "asomething", "asomething", "asomething", "asomething", 80, "avhost");
+            var rabbitmqService5 = extensionConfigProvider.GetService("asomething", "asomething", "asomething", "asomething", "asomething", 80, "avhost");
+            var rabbitmqService6 = extensionConfigProvider.GetService("asomethingElse", "asomething", "asomething", "asomething", "asomething", 80, "avhost");
 
             // 4 and 5 should be equal
             Assert.Equal(rabbitmqService4, rabbitmqService5);

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQOptionsTests.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQOptionsTests.cs
@@ -21,6 +21,7 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
                 { nameof(option.QueueName), option.QueueName },
                 { nameof(option.Port), option.Port },
                 { nameof(option.PrefetchCount), option.PrefetchCount },
+                { nameof(option.VirtualHost), option.VirtualHost },
             };
 
             return options.ToString(Formatting.Indented);
@@ -38,6 +39,7 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
             Assert.Null(options.UserName);
             Assert.Null(options.Password);
             Assert.Null(options.ConnectionString);
+            Assert.Null(options.VirtualHost);
 
             // Test formatted
             Assert.Equal(GetFormattedOption(options), options.Format());
@@ -53,6 +55,7 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
             string expectedUserName = "someUserName";
             string expectedPassword = "somePassword";
             string expectedConnectionString = "someConnectionString";
+            string expectedVirtualHost = "someVirtualHost";
             RabbitMQOptions options = new RabbitMQOptions()
             {
                 Port = expectedPort,
@@ -62,6 +65,7 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
                 Password = expectedPassword,
                 ConnectionString = expectedConnectionString,
                 PrefetchCount = expectedPrefetchCount,
+                VirtualHost = expectedVirtualHost,
             };
 
             Assert.Equal(expectedPrefetchCount, options.PrefetchCount);
@@ -71,6 +75,7 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
             Assert.Equal(expectedUserName, options.UserName);
             Assert.Equal(expectedPassword, options.Password);
             Assert.Equal(expectedConnectionString, options.ConnectionString);
+            Assert.Equal(expectedVirtualHost, options.VirtualHost);
 
             // Test formatted
             Assert.Equal(GetFormattedOption(options), options.Format());

--- a/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQServiceTests.cs
+++ b/test/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQServiceTests.cs
@@ -11,13 +11,13 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
     public class RabbitMQServiceTests
     {
         [Theory]
-        [InlineData("", "localhost", "guest", "guest", 5672, "", "localhost", "guest", "guest", 5672)]
-        [InlineData("amqp://testUserName:testPassword@11.111.111.11:5672", null, null, null, null, "amqp://testUserName:testPassword@11.111.111.11:5672", "11.111.111.11", "testUserName", "testPassword", 5672)]
-        [InlineData("", "localhost", null, null, 0, "", "localhost", "guest", "guest", -1)] // Should fill in "guest", "guest", 5672
-        public void Handles_Connection_Attributes_And_Options(string connectionString, string hostName, string userName, string password, int port,
-            string expectedConnectionString, string expectedHostName, string expectedUserName, string expectedPassword, int expectedPort)
+        [InlineData("", "localhost", "guest", "guest", 5672, "some-vhost", "", "localhost", "guest", "guest", 5672, "some-vhost")]
+        [InlineData("amqp://testUserName:testPassword@11.111.111.11:5672/some-vhost", null, null, null, null, "some-vhost", "amqp://testUserName:testPassword@11.111.111.11:5672/some-vhost", "11.111.111.11", "testUserName", "testPassword", 5672, "some-vhost")]
+        [InlineData("", "localhost", null, null, 0, "some-vhost", "", "localhost", "guest", "guest", -1, "some-vhost")] // Should fill in "guest", "guest", 5672
+        public void Handles_Connection_Attributes_And_Options(string connectionString, string hostName, string userName, string password, int port, string virtualHost,
+            string expectedConnectionString, string expectedHostName, string expectedUserName, string expectedPassword, int expectedPort, string expectedVirtualHost)
         {
-            ConnectionFactory factory = RabbitMQService.GetConnectionFactory(connectionString, hostName, userName, password, port);
+            ConnectionFactory factory = RabbitMQService.GetConnectionFactory(connectionString, hostName, userName, password, port, virtualHost);
 
             if (String.IsNullOrEmpty(connectionString))
             {
@@ -26,6 +26,7 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
                 Assert.Equal(expectedUserName, factory.UserName);
                 Assert.Equal(expectedPassword, factory.Password);
                 Assert.Equal(expectedPort, factory.Port);
+                Assert.Equal(expectedVirtualHost, factory.VirtualHost);
             }
             else
             {
@@ -34,6 +35,7 @@ namespace WebJobs.Extensions.RabbitMQ.Tests
                 Assert.Equal(expectedUserName, factory.UserName);
                 Assert.Equal(expectedPassword, factory.Password);
                 Assert.Equal(expectedPort, factory.Port);
+                Assert.Equal(expectedVirtualHost, factory.VirtualHost);
             }
         }
     }


### PR DESCRIPTION
See https://www.rabbitmq.com/vhosts.html for more details.
It was already possible to use this using the ConnectionString, this allow it
to be used when specifying host/user/password

Fixes: #81