### PR TITLE
Fix resolution of queue-name in output binding

### DIFF
--- a/java-library/src/main/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQOutput.java
+++ b/java-library/src/main/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQOutput.java
@@ -34,7 +34,6 @@ import java.lang.annotation.Target;
  *     output.setValue(message);
  * }
  * </pre>
- *
  */
 
 @Retention(RetentionPolicy.RUNTIME)

--- a/java-library/src/main/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQTrigger.java
+++ b/java-library/src/main/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQTrigger.java
@@ -21,7 +21,7 @@ import java.lang.annotation.Target;
  * </p>
  *
  * <p>
- * Example function that uses a RabbitMQ trigger:
+ * Example function that uses a RabbitMQ trigger binding:
  * </p>
  *
  * <pre>

--- a/src/RabbitMQAttribute.cs
+++ b/src/RabbitMQAttribute.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Azure.WebJobs
         /// <summary>
         /// Gets or sets the RabbitMQ queue name.
         /// </summary>
+        [AutoResolve]
         public string QueueName { get; set; }
 
         /// <summary>


### PR DESCRIPTION
It is required to have `[AutoResolve]` attribute applied on properties (e.g. `QueueName`) in the C# attributes used for output binding (e.g. `RabbitMQAttribute`). Without this, the values will not be resolved from the app settings. For example, the setting `RabbitMqOutQueueName` won't be queried from app settings if following attribute is applied on a function:

```cs
[return: RabbitMQ(QueueName = "%RabbitMqOutQueueName%", ConnectionStringSetting = "RabbitMqConnectionString")]
```

This does not seem to be a requirement for trigger attributes. E.g. [CosmosDBTriggerAttribute](https://github.com/Azure/azure-webjobs-sdk-extensions/blob/dev/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttribute.cs) does not require `[AutoResolve]` attribute for any of the class properties, but [CosmosDBAttribute](https://github.com/Azure/azure-webjobs-sdk-extensions/blob/dev/src/WebJobs.Extensions.CosmosDB/CosmosDBAttribute.cs) requires them.

As per my testing, if it is a C# function app, the function invocation does not show any error but does not even push the return message to RabbitMQ output queue. In case of Java function app, every function invocation results in an error message since queue `%RabbitMqOutQueueName%` does not exist.

I have verified that the changes from PR fixes issue for both C# and Java function apps.