### PR TITLE
Enable Automatic Recovery

### DIFF
--- a/extension/WebJobs.Extensions.RabbitMQ/Services/RabbitMQService.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Services/RabbitMQService.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             {
                 Uri = new Uri(connectionString),
             };
-            
+
             connectionFactory.AutomaticRecoveryEnabled = true;
 
             if (disableCertificateValidation && connectionFactory.Ssl.Enabled)

--- a/extension/WebJobs.Extensions.RabbitMQ/Services/RabbitMQService.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Services/RabbitMQService.cs
@@ -27,6 +27,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             {
                 Uri = new Uri(connectionString),
             };
+            
+            connectionFactory.AutomaticRecoveryEnabled = true;
 
             if (disableCertificateValidation && connectionFactory.Ssl.Enabled)
             {


### PR DESCRIPTION
When connection errors occur, the RabbitMQ client does NOT recover automatically unless we set AutomaticRecoveryEnabled to true in our connection factory.

https://www.rabbitmq.com/dotnet-api-guide.html#connection-recovery