### PR TITLE
Remove StyleCop suppressions and resolve style issues

### DIFF
--- a/extension/.editorconfig
+++ b/extension/.editorconfig
@@ -27,10 +27,10 @@ charset = utf-8-bom
 # Organize usings
 dotnet_sort_system_directives_first = true
 # this. preferences
-dotnet_style_qualification_for_field = false:silent
-dotnet_style_qualification_for_property = false:silent
-dotnet_style_qualification_for_method = false:silent
-dotnet_style_qualification_for_event = false:silent
+dotnet_style_qualification_for_field = true:silent
+dotnet_style_qualification_for_property = true:silent
+dotnet_style_qualification_for_method = true:silent
+dotnet_style_qualification_for_event = true:silent
 # Language keywords vs BCL types preferences
 dotnet_style_predefined_type_for_locals_parameters_members = true:silent
 dotnet_style_predefined_type_for_member_access = true:silent
@@ -76,7 +76,6 @@ dotnet_diagnostic.CA1716.severity = none # Identifiers should not match keywords
 dotnet_diagnostic.IDE0058.severity = none # Remove unnecessary expression value
 dotnet_diagnostic.IDE0130.severity = none # Namespace does not match folder structure
 dotnet_diagnostic.SA0001.severity = none # XML comment analysis is disabled (to be removed)
-dotnet_diagnostic.SA1101.severity = none # Prefix local calls with this
 
 ###############################
 # C# Coding Conventions       #

--- a/extension/.editorconfig
+++ b/extension/.editorconfig
@@ -78,7 +78,6 @@ dotnet_diagnostic.IDE0130.severity = none # Namespace does not match folder stru
 dotnet_diagnostic.SA0001.severity = none # XML comment analysis is disabled (to be removed)
 dotnet_diagnostic.SA1101.severity = none # Prefix local calls with this
 dotnet_diagnostic.SA1202.severity = none # Elements must be ordered by access (to be removed)
-dotnet_diagnostic.SA1309.severity = none # Field name should not begin with an underscore (to be removed)
 
 ###############################
 # C# Coding Conventions       #

--- a/extension/.editorconfig
+++ b/extension/.editorconfig
@@ -6,6 +6,7 @@ root = true
 # All files
 [*]
 indent_style = space
+insert_final_newline = true
 
 # XML project files
 [*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
@@ -18,7 +19,6 @@ indent_size = 2
 # Code files
 [*.{cs,csx,vb,vbx}]
 indent_size = 4
-insert_final_newline = true
 charset = utf-8-bom
 ###############################
 # .NET Coding Conventions     #

--- a/extension/.editorconfig
+++ b/extension/.editorconfig
@@ -77,7 +77,6 @@ dotnet_diagnostic.IDE0058.severity = none # Remove unnecessary expression value
 dotnet_diagnostic.IDE0130.severity = none # Namespace does not match folder structure
 dotnet_diagnostic.SA0001.severity = none # XML comment analysis is disabled (to be removed)
 dotnet_diagnostic.SA1101.severity = none # Prefix local calls with this
-dotnet_diagnostic.SA1202.severity = none # Elements must be ordered by access (to be removed)
 
 ###############################
 # C# Coding Conventions       #

--- a/extension/.vscode/extensions.json
+++ b/extension/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
     "recommendations": [
-        "ms-dotnettools.csharp"
+        "ms-dotnettools.csharp",
+        "EditorConfig.EditorConfig"
     ]
 }

--- a/extension/.vscode/settings.json
+++ b/extension/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
     "editor.formatOnSave": true,
     "files.insertFinalNewline": true,
-    "files.trimFinalNewlines": true
+    "files.trimFinalNewlines": true,
+    "omnisharp.enableEditorConfigSupport": true,
+    "omnisharp.enableRoslynAnalyzers": true
 }

--- a/extension/WebJobs.Extensions.RabbitMQ.Samples/SamplesTypeLocator.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.Samples/SamplesTypeLocator.cs
@@ -8,16 +8,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Samples
 {
     public class SamplesTypeLocator : ITypeLocator
     {
-        private readonly Type[] _types;
+        private readonly Type[] types;
 
         public SamplesTypeLocator(params Type[] types)
         {
-            _types = types;
+            this.types = types;
         }
 
         public IReadOnlyList<Type> GetTypes()
         {
-            return _types;
+            return types;
         }
     }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ.Samples/SamplesTypeLocator.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.Samples/SamplesTypeLocator.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Samples
 
         public IReadOnlyList<Type> GetTypes()
         {
-            return types;
+            return this.types;
         }
     }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ.Tests/BasicDeliverEventArgsValueProviderTests.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.Tests/BasicDeliverEventArgsValueProviderTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
             var actualObject = (BasicDeliverEventArgs)await testValueProvider.GetValueAsync();
 
             Assert.Equal(actualObject, exceptedObject);
-            Assert.True(object.ReferenceEquals(actualObject, exceptedObject));
+            Assert.True(ReferenceEquals(actualObject, exceptedObject));
             Assert.Equal(typeof(BasicDeliverEventArgs), testValueProvider.Type);
         }
 

--- a/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQClientBuilderTests.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQClientBuilderTests.cs
@@ -12,14 +12,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
 {
     public class RabbitMQClientBuilderTests
     {
-        private static readonly IConfiguration _emptyConfig = new ConfigurationBuilder().Build();
+        private static readonly IConfiguration EmptyConfig = new ConfigurationBuilder().Build();
 
         [Fact]
         public void Opens_Connection()
         {
             var options = new OptionsWrapper<RabbitMQOptions>(new RabbitMQOptions());
             var mockServiceFactory = new Mock<IRabbitMQServiceFactory>();
-            var config = new RabbitMQExtensionConfigProvider(options, new Mock<INameResolver>().Object, mockServiceFactory.Object, new LoggerFactory(), _emptyConfig);
+            var config = new RabbitMQExtensionConfigProvider(options, new Mock<INameResolver>().Object, mockServiceFactory.Object, new LoggerFactory(), EmptyConfig);
             mockServiceFactory.Setup(m => m.CreateService(It.IsAny<string>(), false)).Returns(new Mock<IRabbitMQService>().Object);
             RabbitMQAttribute attr = GetTestAttribute();
 
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
             var mockServiceFactory = new Mock<IRabbitMQServiceFactory>();
             mockServiceFactory.SetupSequence(m => m.CreateService(It.IsAny<string>(), false))
                 .Returns(GetRabbitMQService());
-            var config = new RabbitMQExtensionConfigProvider(options, new Mock<INameResolver>().Object, mockServiceFactory.Object, new LoggerFactory(), _emptyConfig);
+            var config = new RabbitMQExtensionConfigProvider(options, new Mock<INameResolver>().Object, mockServiceFactory.Object, new LoggerFactory(), EmptyConfig);
             RabbitMQAttribute attr = GetTestAttribute();
 
             var clientBuilder = new RabbitMQClientBuilder(config, options);

--- a/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQConfigProviderTests.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQConfigProviderTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
 {
     public class RabbitMQConfigProviderTests
     {
-        private static readonly IConfiguration _emptyConfig = new ConfigurationBuilder().Build();
+        private static readonly IConfiguration EmptyConfig = new ConfigurationBuilder().Build();
 
         [Fact]
         public void Creates_Context_Correctly()
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
             var loggerFactory = new LoggerFactory();
             var mockServiceFactory = new Mock<IRabbitMQServiceFactory>();
             var mockNameResolver = new Mock<INameResolver>();
-            var config = new RabbitMQExtensionConfigProvider(new OptionsWrapper<RabbitMQOptions>(options), mockNameResolver.Object, mockServiceFactory.Object, loggerFactory, _emptyConfig);
+            var config = new RabbitMQExtensionConfigProvider(new OptionsWrapper<RabbitMQOptions>(options), mockNameResolver.Object, mockServiceFactory.Object, loggerFactory, EmptyConfig);
             var attribute = new RabbitMQAttribute { ConnectionStringSetting = "connectionStringSettingFromAttribute", QueueName = "queueNameFromAttributes" };
 
             RabbitMQContext actualContext = config.CreateContext(attribute);
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
             var loggerFactory = new LoggerFactory();
             var mockServiceFactory = new Mock<IRabbitMQServiceFactory>();
             var mockNameResolver = new Mock<INameResolver>();
-            var config = new RabbitMQExtensionConfigProvider(new OptionsWrapper<RabbitMQOptions>(opt), mockNameResolver.Object, mockServiceFactory.Object, loggerFactory, _emptyConfig);
+            var config = new RabbitMQExtensionConfigProvider(new OptionsWrapper<RabbitMQOptions>(opt), mockNameResolver.Object, mockServiceFactory.Object, loggerFactory, EmptyConfig);
             RabbitMQContext actualContext = config.CreateContext(attr);
 
             if (optConnectionString == null && optQueueName == null)

--- a/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQListenerTests.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQListenerTests.cs
@@ -18,81 +18,81 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
 {
     public class RabbitMQListenerTests
     {
-        private readonly Mock<ITriggeredFunctionExecutor> _mockExecutor;
-        private readonly Mock<IRabbitMQService> _mockService;
-        private readonly Mock<ILogger> _mockLogger;
-        private readonly Mock<IRabbitMQModel> _mockModel;
-        private readonly Mock<FunctionDescriptor> _mockDescriptor;
-        private readonly RabbitMQListener _testListener;
+        private readonly Mock<ITriggeredFunctionExecutor> mockExecutor;
+        private readonly Mock<IRabbitMQService> mockService;
+        private readonly Mock<ILogger> mockLogger;
+        private readonly Mock<IRabbitMQModel> mockModel;
+        private readonly Mock<FunctionDescriptor> mockDescriptor;
+        private readonly RabbitMQListener testListener;
 
         public RabbitMQListenerTests()
         {
-            _mockExecutor = new Mock<ITriggeredFunctionExecutor>();
-            _mockService = new Mock<IRabbitMQService>();
-            _mockLogger = new Mock<ILogger>();
-            _mockModel = new Mock<IRabbitMQModel>();
-            _mockDescriptor = new Mock<FunctionDescriptor>();
+            mockExecutor = new Mock<ITriggeredFunctionExecutor>();
+            mockService = new Mock<IRabbitMQService>();
+            mockLogger = new Mock<ILogger>();
+            mockModel = new Mock<IRabbitMQModel>();
+            mockDescriptor = new Mock<FunctionDescriptor>();
 
-            _mockService.Setup(m => m.RabbitMQModel).Returns(_mockModel.Object);
+            mockService.Setup(m => m.RabbitMQModel).Returns(mockModel.Object);
             var queueInfo = new QueueDeclareOk("blah", 5, 1);
-            _mockModel.Setup(m => m.QueueDeclarePassive(It.IsAny<string>())).Returns(queueInfo);
+            mockModel.Setup(m => m.QueueDeclarePassive(It.IsAny<string>())).Returns(queueInfo);
 
-            _testListener = new RabbitMQListener(_mockExecutor.Object, _mockService.Object, "blah", _mockLogger.Object, new FunctionDescriptor { Id = "TestFunction" }, 30);
+            testListener = new RabbitMQListener(mockExecutor.Object, mockService.Object, "blah", mockLogger.Object, new FunctionDescriptor { Id = "TestFunction" }, 30);
         }
 
         [Fact]
         public void CreatesHeadersAndRepublishes()
         {
             string queueName = "blah";
-            _mockService.Setup(m => m.RabbitMQModel).Returns(_mockModel.Object);
-            var listener = new RabbitMQListener(_mockExecutor.Object, _mockService.Object, queueName, _mockLogger.Object, _mockDescriptor.Object, 30);
+            mockService.Setup(m => m.RabbitMQModel).Returns(mockModel.Object);
+            var listener = new RabbitMQListener(mockExecutor.Object, mockService.Object, queueName, mockLogger.Object, mockDescriptor.Object, 30);
 
             IBasicProperties properties = Mock.Of<IBasicProperties>();
             var args = new BasicDeliverEventArgs("tag", 1, false, string.Empty, "routingKey", properties, Encoding.UTF8.GetBytes("hello world"));
             listener.CreateHeadersAndRepublish(args);
 
-            _mockModel.Verify(m => m.BasicAck(It.IsAny<ulong>(), false), Times.Exactly(1));
-            _mockModel.Verify(m => m.BasicPublish(It.IsAny<string>(), queueName, It.IsAny<IBasicProperties>(), It.IsAny<ReadOnlyMemory<byte>>()), Times.Exactly(1));
+            mockModel.Verify(m => m.BasicAck(It.IsAny<ulong>(), false), Times.Exactly(1));
+            mockModel.Verify(m => m.BasicPublish(It.IsAny<string>(), queueName, It.IsAny<IBasicProperties>(), It.IsAny<ReadOnlyMemory<byte>>()), Times.Exactly(1));
         }
 
         [Fact]
         public void RepublishesMessages()
         {
             string queueName = "blah";
-            _mockService.Setup(m => m.RabbitMQModel).Returns(_mockModel.Object);
-            var listener = new RabbitMQListener(_mockExecutor.Object, _mockService.Object, queueName, _mockLogger.Object, _mockDescriptor.Object, 30);
+            mockService.Setup(m => m.RabbitMQModel).Returns(mockModel.Object);
+            var listener = new RabbitMQListener(mockExecutor.Object, mockService.Object, queueName, mockLogger.Object, mockDescriptor.Object, 30);
 
             IBasicProperties properties = Mock.Of<IBasicProperties>(property => property.Headers == new Dictionary<string, object>() { { "requeueCount", 1 } });
             var args = new BasicDeliverEventArgs("tag", 1, false, string.Empty, "routingKey", properties, Encoding.UTF8.GetBytes("hello world"));
             listener.RepublishMessages(args);
 
-            _mockModel.Verify(m => m.BasicAck(It.IsAny<ulong>(), false), Times.Exactly(1));
-            _mockModel.Verify(m => m.BasicPublish(It.IsAny<string>(), queueName, It.IsAny<IBasicProperties>(), It.IsAny<ReadOnlyMemory<byte>>()), Times.Exactly(1));
+            mockModel.Verify(m => m.BasicAck(It.IsAny<ulong>(), false), Times.Exactly(1));
+            mockModel.Verify(m => m.BasicPublish(It.IsAny<string>(), queueName, It.IsAny<IBasicProperties>(), It.IsAny<ReadOnlyMemory<byte>>()), Times.Exactly(1));
         }
 
         [Fact]
         public void RejectsStaleMessages()
         {
-            _mockService.Setup(m => m.RabbitMQModel).Returns(_mockModel.Object);
-            var listener = new RabbitMQListener(_mockExecutor.Object, _mockService.Object, "blah", _mockLogger.Object, _mockDescriptor.Object, 30);
+            mockService.Setup(m => m.RabbitMQModel).Returns(mockModel.Object);
+            var listener = new RabbitMQListener(mockExecutor.Object, mockService.Object, "blah", mockLogger.Object, mockDescriptor.Object, 30);
 
             IBasicProperties properties = Mock.Of<IBasicProperties>(property => property.Headers == new Dictionary<string, object>() { { "requeueCount", 6 } });
             var args = new BasicDeliverEventArgs("tag", 1, false, string.Empty, "queue", properties, Encoding.UTF8.GetBytes("hello world"));
             listener.RepublishMessages(args);
 
-            _mockModel.Verify(m => m.BasicReject(It.IsAny<ulong>(), false), Times.Exactly(1));
+            mockModel.Verify(m => m.BasicReject(It.IsAny<ulong>(), false), Times.Exactly(1));
         }
 
         [Fact]
         public void ScaleMonitor_Id_ReturnsExpectedValue()
         {
-            Assert.Equal("testfunction-rabbitmqtrigger-blah", _testListener.Descriptor.Id);
+            Assert.Equal("testfunction-rabbitmqtrigger-blah", testListener.Descriptor.Id);
         }
 
         [Fact]
         public async Task GetMetrics_ReturnsExpectedResult()
         {
-            var listener = new RabbitMQListener(_mockExecutor.Object, _mockService.Object, "listener_test_queue", _mockLogger.Object, new FunctionDescriptor { Id = "TestFunction" }, 30);
+            var listener = new RabbitMQListener(mockExecutor.Object, mockService.Object, "listener_test_queue", mockLogger.Object, new FunctionDescriptor { Id = "TestFunction" }, 30);
             RabbitMQTriggerMetrics metrics = await listener.GetMetricsAsync();
 
             Assert.Equal(5U, metrics.QueueLength);
@@ -107,10 +107,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
                 WorkerCount = 1,
             };
 
-            ScaleStatus status = _testListener.GetScaleStatus(context);
+            ScaleStatus status = testListener.GetScaleStatus(context);
             Assert.Equal(ScaleVote.None, status.Vote);
 
-            status = ((IScaleMonitor)_testListener).GetScaleStatus(context);
+            status = ((IScaleMonitor)testListener).GetScaleStatus(context);
             Assert.Equal(ScaleVote.None, status.Vote);
         }
 
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
                 Metrics = metrics,
             };
 
-            ScaleStatus status = _testListener.GetScaleStatus(context);
+            ScaleStatus status = testListener.GetScaleStatus(context);
             Assert.Equal(ScaleVote.ScaleOut, status.Vote);
 
             // verify again with a non generic context instance
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
                 Metrics = metrics,
             };
 
-            status = ((IScaleMonitor)_testListener).GetScaleStatus(context2);
+            status = ((IScaleMonitor)testListener).GetScaleStatus(context2);
             Assert.Equal(ScaleVote.ScaleOut, status.Vote);
         }
 
@@ -168,7 +168,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
                 },
             };
 
-            ScaleStatus status = _testListener.GetScaleStatus(context);
+            ScaleStatus status = testListener.GetScaleStatus(context);
 
             Assert.Equal(ScaleVote.ScaleOut, status.Vote);
         }
@@ -192,7 +192,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
                 },
             };
 
-            ScaleStatus status = _testListener.GetScaleStatus(context);
+            ScaleStatus status = testListener.GetScaleStatus(context);
 
             Assert.Equal(ScaleVote.ScaleIn, status.Vote);
         }
@@ -216,7 +216,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
                 },
             };
 
-            ScaleStatus status = _testListener.GetScaleStatus(context);
+            ScaleStatus status = testListener.GetScaleStatus(context);
 
             Assert.Equal(ScaleVote.None, status.Vote);
         }
@@ -240,7 +240,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
                 },
             };
 
-            ScaleStatus status = _testListener.GetScaleStatus(context);
+            ScaleStatus status = testListener.GetScaleStatus(context);
 
             Assert.Equal(ScaleVote.ScaleIn, status.Vote);
         }
@@ -257,7 +257,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
                 },
             };
 
-            ScaleStatus status = _testListener.GetScaleStatus(context);
+            ScaleStatus status = testListener.GetScaleStatus(context);
 
             Assert.Equal(ScaleVote.None, status.Vote);
         }

--- a/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQListenerTests.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQListenerTests.cs
@@ -27,72 +27,72 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
 
         public RabbitMQListenerTests()
         {
-            mockExecutor = new Mock<ITriggeredFunctionExecutor>();
-            mockService = new Mock<IRabbitMQService>();
-            mockLogger = new Mock<ILogger>();
-            mockModel = new Mock<IRabbitMQModel>();
-            mockDescriptor = new Mock<FunctionDescriptor>();
+            this.mockExecutor = new Mock<ITriggeredFunctionExecutor>();
+            this.mockService = new Mock<IRabbitMQService>();
+            this.mockLogger = new Mock<ILogger>();
+            this.mockModel = new Mock<IRabbitMQModel>();
+            this.mockDescriptor = new Mock<FunctionDescriptor>();
 
-            mockService.Setup(m => m.RabbitMQModel).Returns(mockModel.Object);
+            this.mockService.Setup(m => m.RabbitMQModel).Returns(this.mockModel.Object);
             var queueInfo = new QueueDeclareOk("blah", 5, 1);
-            mockModel.Setup(m => m.QueueDeclarePassive(It.IsAny<string>())).Returns(queueInfo);
+            this.mockModel.Setup(m => m.QueueDeclarePassive(It.IsAny<string>())).Returns(queueInfo);
 
-            testListener = new RabbitMQListener(mockExecutor.Object, mockService.Object, "blah", mockLogger.Object, new FunctionDescriptor { Id = "TestFunction" }, 30);
+            this.testListener = new RabbitMQListener(this.mockExecutor.Object, this.mockService.Object, "blah", this.mockLogger.Object, new FunctionDescriptor { Id = "TestFunction" }, 30);
         }
 
         [Fact]
         public void CreatesHeadersAndRepublishes()
         {
             string queueName = "blah";
-            mockService.Setup(m => m.RabbitMQModel).Returns(mockModel.Object);
-            var listener = new RabbitMQListener(mockExecutor.Object, mockService.Object, queueName, mockLogger.Object, mockDescriptor.Object, 30);
+            this.mockService.Setup(m => m.RabbitMQModel).Returns(this.mockModel.Object);
+            var listener = new RabbitMQListener(this.mockExecutor.Object, this.mockService.Object, queueName, this.mockLogger.Object, this.mockDescriptor.Object, 30);
 
             IBasicProperties properties = Mock.Of<IBasicProperties>();
             var args = new BasicDeliverEventArgs("tag", 1, false, string.Empty, "routingKey", properties, Encoding.UTF8.GetBytes("hello world"));
             listener.CreateHeadersAndRepublish(args);
 
-            mockModel.Verify(m => m.BasicAck(It.IsAny<ulong>(), false), Times.Exactly(1));
-            mockModel.Verify(m => m.BasicPublish(It.IsAny<string>(), queueName, It.IsAny<IBasicProperties>(), It.IsAny<ReadOnlyMemory<byte>>()), Times.Exactly(1));
+            this.mockModel.Verify(m => m.BasicAck(It.IsAny<ulong>(), false), Times.Exactly(1));
+            this.mockModel.Verify(m => m.BasicPublish(It.IsAny<string>(), queueName, It.IsAny<IBasicProperties>(), It.IsAny<ReadOnlyMemory<byte>>()), Times.Exactly(1));
         }
 
         [Fact]
         public void RepublishesMessages()
         {
             string queueName = "blah";
-            mockService.Setup(m => m.RabbitMQModel).Returns(mockModel.Object);
-            var listener = new RabbitMQListener(mockExecutor.Object, mockService.Object, queueName, mockLogger.Object, mockDescriptor.Object, 30);
+            this.mockService.Setup(m => m.RabbitMQModel).Returns(this.mockModel.Object);
+            var listener = new RabbitMQListener(this.mockExecutor.Object, this.mockService.Object, queueName, this.mockLogger.Object, this.mockDescriptor.Object, 30);
 
             IBasicProperties properties = Mock.Of<IBasicProperties>(property => property.Headers == new Dictionary<string, object>() { { "requeueCount", 1 } });
             var args = new BasicDeliverEventArgs("tag", 1, false, string.Empty, "routingKey", properties, Encoding.UTF8.GetBytes("hello world"));
             listener.RepublishMessages(args);
 
-            mockModel.Verify(m => m.BasicAck(It.IsAny<ulong>(), false), Times.Exactly(1));
-            mockModel.Verify(m => m.BasicPublish(It.IsAny<string>(), queueName, It.IsAny<IBasicProperties>(), It.IsAny<ReadOnlyMemory<byte>>()), Times.Exactly(1));
+            this.mockModel.Verify(m => m.BasicAck(It.IsAny<ulong>(), false), Times.Exactly(1));
+            this.mockModel.Verify(m => m.BasicPublish(It.IsAny<string>(), queueName, It.IsAny<IBasicProperties>(), It.IsAny<ReadOnlyMemory<byte>>()), Times.Exactly(1));
         }
 
         [Fact]
         public void RejectsStaleMessages()
         {
-            mockService.Setup(m => m.RabbitMQModel).Returns(mockModel.Object);
-            var listener = new RabbitMQListener(mockExecutor.Object, mockService.Object, "blah", mockLogger.Object, mockDescriptor.Object, 30);
+            this.mockService.Setup(m => m.RabbitMQModel).Returns(this.mockModel.Object);
+            var listener = new RabbitMQListener(this.mockExecutor.Object, this.mockService.Object, "blah", this.mockLogger.Object, this.mockDescriptor.Object, 30);
 
             IBasicProperties properties = Mock.Of<IBasicProperties>(property => property.Headers == new Dictionary<string, object>() { { "requeueCount", 6 } });
             var args = new BasicDeliverEventArgs("tag", 1, false, string.Empty, "queue", properties, Encoding.UTF8.GetBytes("hello world"));
             listener.RepublishMessages(args);
 
-            mockModel.Verify(m => m.BasicReject(It.IsAny<ulong>(), false), Times.Exactly(1));
+            this.mockModel.Verify(m => m.BasicReject(It.IsAny<ulong>(), false), Times.Exactly(1));
         }
 
         [Fact]
         public void ScaleMonitor_Id_ReturnsExpectedValue()
         {
-            Assert.Equal("testfunction-rabbitmqtrigger-blah", testListener.Descriptor.Id);
+            Assert.Equal("testfunction-rabbitmqtrigger-blah", this.testListener.Descriptor.Id);
         }
 
         [Fact]
         public async Task GetMetrics_ReturnsExpectedResult()
         {
-            var listener = new RabbitMQListener(mockExecutor.Object, mockService.Object, "listener_test_queue", mockLogger.Object, new FunctionDescriptor { Id = "TestFunction" }, 30);
+            var listener = new RabbitMQListener(this.mockExecutor.Object, this.mockService.Object, "listener_test_queue", this.mockLogger.Object, new FunctionDescriptor { Id = "TestFunction" }, 30);
             RabbitMQTriggerMetrics metrics = await listener.GetMetricsAsync();
 
             Assert.Equal(5U, metrics.QueueLength);
@@ -107,10 +107,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
                 WorkerCount = 1,
             };
 
-            ScaleStatus status = testListener.GetScaleStatus(context);
+            ScaleStatus status = this.testListener.GetScaleStatus(context);
             Assert.Equal(ScaleVote.None, status.Vote);
 
-            status = ((IScaleMonitor)testListener).GetScaleStatus(context);
+            status = ((IScaleMonitor)this.testListener).GetScaleStatus(context);
             Assert.Equal(ScaleVote.None, status.Vote);
         }
 
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
                 Metrics = metrics,
             };
 
-            ScaleStatus status = testListener.GetScaleStatus(context);
+            ScaleStatus status = this.testListener.GetScaleStatus(context);
             Assert.Equal(ScaleVote.ScaleOut, status.Vote);
 
             // verify again with a non generic context instance
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
                 Metrics = metrics,
             };
 
-            status = ((IScaleMonitor)testListener).GetScaleStatus(context2);
+            status = ((IScaleMonitor)this.testListener).GetScaleStatus(context2);
             Assert.Equal(ScaleVote.ScaleOut, status.Vote);
         }
 
@@ -168,7 +168,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
                 },
             };
 
-            ScaleStatus status = testListener.GetScaleStatus(context);
+            ScaleStatus status = this.testListener.GetScaleStatus(context);
 
             Assert.Equal(ScaleVote.ScaleOut, status.Vote);
         }
@@ -192,7 +192,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
                 },
             };
 
-            ScaleStatus status = testListener.GetScaleStatus(context);
+            ScaleStatus status = this.testListener.GetScaleStatus(context);
 
             Assert.Equal(ScaleVote.ScaleIn, status.Vote);
         }
@@ -216,7 +216,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
                 },
             };
 
-            ScaleStatus status = testListener.GetScaleStatus(context);
+            ScaleStatus status = this.testListener.GetScaleStatus(context);
 
             Assert.Equal(ScaleVote.None, status.Vote);
         }
@@ -240,7 +240,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
                 },
             };
 
-            ScaleStatus status = testListener.GetScaleStatus(context);
+            ScaleStatus status = this.testListener.GetScaleStatus(context);
 
             Assert.Equal(ScaleVote.ScaleIn, status.Vote);
         }
@@ -257,7 +257,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
                 },
             };
 
-            ScaleStatus status = testListener.GetScaleStatus(context);
+            ScaleStatus status = this.testListener.GetScaleStatus(context);
 
             Assert.Equal(ScaleVote.None, status.Vote);
         }

--- a/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQOptionsTests.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQOptionsTests.cs
@@ -12,19 +12,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
 {
     public class RabbitMQOptionsTests
     {
-        // TODO: Do not immitate source code.
-        private static string GetFormattedOption(RabbitMQOptions option)
-        {
-            var options = new JObject
-            {
-                { nameof(option.QueueName), option.QueueName },
-                { nameof(option.PrefetchCount), option.PrefetchCount },
-                { nameof(option.DisableCertificateValidation), option.DisableCertificateValidation },
-            };
-
-            return options.ToString(Formatting.Indented);
-        }
-
         [Fact]
         public void TestDefaultOptions()
         {
@@ -83,6 +70,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
                 IOptions<RabbitMQOptions> config = host.Services.GetService<IOptions<RabbitMQOptions>>();
                 Assert.Equal(config.Value.PrefetchCount, expectedPrefetchCount);
             }
+        }
+
+        // TODO: Do not immitate source code.
+        private static string GetFormattedOption(RabbitMQOptions option)
+        {
+            var options = new JObject
+            {
+                { nameof(option.QueueName), option.QueueName },
+                { nameof(option.PrefetchCount), option.PrefetchCount },
+                { nameof(option.DisableCertificateValidation), option.DisableCertificateValidation },
+            };
+
+            return options.ToString(Formatting.Indented);
         }
     }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ.Tests/UtilityTests.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.Tests/UtilityTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
         [InlineData("rabbitMQTest", "hello", "amqp://guest:guest@tada:5672")]
         public void ResolveConnectionString(string attributeConnectionString, string optionsConnectionString, string expectedResolvedString)
         {
-            string resolvedString = Utility.ResolveConnectionString(attributeConnectionString, optionsConnectionString, emptyConfig);
+            string resolvedString = Utility.ResolveConnectionString(attributeConnectionString, optionsConnectionString, this.emptyConfig);
             Assert.Equal(expectedResolvedString, resolvedString);
         }
     }

--- a/extension/WebJobs.Extensions.RabbitMQ.Tests/UtilityTests.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.Tests/UtilityTests.cs
@@ -8,14 +8,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests
 {
     public class UtilityTests
     {
-        private readonly IConfiguration _emptyConfig = new ConfigurationBuilder().AddJsonFile("testappsettings.json").Build();
+        private readonly IConfiguration emptyConfig = new ConfigurationBuilder().AddJsonFile("testappsettings.json").Build();
 
         [Theory]
         [InlineData("", "hello", "hello")]
         [InlineData("rabbitMQTest", "hello", "amqp://guest:guest@tada:5672")]
         public void ResolveConnectionString(string attributeConnectionString, string optionsConnectionString, string expectedResolvedString)
         {
-            string resolvedString = Utility.ResolveConnectionString(attributeConnectionString, optionsConnectionString, _emptyConfig);
+            string resolvedString = Utility.ResolveConnectionString(attributeConnectionString, optionsConnectionString, emptyConfig);
             Assert.Equal(expectedResolvedString, resolvedString);
         }
     }

--- a/extension/WebJobs.Extensions.RabbitMQ/Bindings/RabbitMQAsyncCollector.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Bindings/RabbitMQAsyncCollector.cs
@@ -24,11 +24,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
         public Task AddAsync(ReadOnlyMemory<byte> message, CancellationToken cancellationToken = default)
         {
-            logger.LogDebug("Adding message to batch for publishing...");
+            this.logger.LogDebug("Adding message to batch for publishing...");
 
-            lock (context.Service.PublishBatchLock)
+            lock (this.context.Service.PublishBatchLock)
             {
-                context.Service.BasicPublishBatch.Add(exchange: string.Empty, routingKey: context.ResolvedAttribute.QueueName, mandatory: false, properties: null, body: message);
+                this.context.Service.BasicPublishBatch.Add(exchange: string.Empty, routingKey: this.context.ResolvedAttribute.QueueName, mandatory: false, properties: null, body: message);
             }
 
             return Task.CompletedTask;
@@ -36,17 +36,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
         public Task FlushAsync(CancellationToken cancellationToken = default)
         {
-            return PublishAsync();
+            return this.PublishAsync();
         }
 
         internal Task PublishAsync()
         {
-            logger.LogDebug("Publishing messages to queue.");
+            this.logger.LogDebug("Publishing messages to queue.");
 
-            lock (context.Service.PublishBatchLock)
+            lock (this.context.Service.PublishBatchLock)
             {
-                context.Service.BasicPublishBatch.Publish();
-                context.Service.ResetPublishBatch();
+                this.context.Service.BasicPublishBatch.Publish();
+                this.context.Service.ResetPublishBatch();
             }
 
             return Task.CompletedTask;

--- a/extension/WebJobs.Extensions.RabbitMQ/Bindings/RabbitMQAsyncCollector.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Bindings/RabbitMQAsyncCollector.cs
@@ -11,24 +11,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     internal class RabbitMQAsyncCollector : IAsyncCollector<ReadOnlyMemory<byte>>
     {
-        private readonly RabbitMQContext _context;
-        private readonly ILogger _logger;
+        private readonly RabbitMQContext context;
+        private readonly ILogger logger;
 
         public RabbitMQAsyncCollector(RabbitMQContext context, ILogger logger)
         {
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _ = context ?? throw new ArgumentNullException(nameof(context));
             _ = context.Service ?? throw new ArgumentException("Value cannot be null. Parameter name: context.Service");
-            _context = context;
+            this.context = context;
         }
 
         public Task AddAsync(ReadOnlyMemory<byte> message, CancellationToken cancellationToken = default)
         {
-            _logger.LogDebug("Adding message to batch for publishing...");
+            logger.LogDebug("Adding message to batch for publishing...");
 
-            lock (_context.Service.PublishBatchLock)
+            lock (context.Service.PublishBatchLock)
             {
-                _context.Service.BasicPublishBatch.Add(exchange: string.Empty, routingKey: _context.ResolvedAttribute.QueueName, mandatory: false, properties: null, body: message);
+                context.Service.BasicPublishBatch.Add(exchange: string.Empty, routingKey: context.ResolvedAttribute.QueueName, mandatory: false, properties: null, body: message);
             }
 
             return Task.CompletedTask;
@@ -41,12 +41,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
         internal Task PublishAsync()
         {
-            _logger.LogDebug("Publishing messages to queue.");
+            logger.LogDebug("Publishing messages to queue.");
 
-            lock (_context.Service.PublishBatchLock)
+            lock (context.Service.PublishBatchLock)
             {
-                _context.Service.BasicPublishBatch.Publish();
-                _context.Service.ResetPublishBatch();
+                context.Service.BasicPublishBatch.Publish();
+                context.Service.ResetPublishBatch();
             }
 
             return Task.CompletedTask;

--- a/extension/WebJobs.Extensions.RabbitMQ/Bindings/RabbitMQClientBuilder.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Bindings/RabbitMQClientBuilder.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
         public IModel Convert(RabbitMQAttribute attribute)
         {
-            return CreateModelFromAttribute(attribute);
+            return this.CreateModelFromAttribute(attribute);
         }
 
         private IModel CreateModelFromAttribute(RabbitMQAttribute attribute)
@@ -30,10 +30,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 throw new ArgumentNullException(nameof(attribute));
             }
 
-            string resolvedConnectionString = Utility.FirstOrDefault(attribute.ConnectionStringSetting, options.Value.ConnectionString);
-            bool resolvedDisableCertificateValidation = Utility.FirstOrDefault(attribute.DisableCertificateValidation, options.Value.DisableCertificateValidation);
+            string resolvedConnectionString = Utility.FirstOrDefault(attribute.ConnectionStringSetting, this.options.Value.ConnectionString);
+            bool resolvedDisableCertificateValidation = Utility.FirstOrDefault(attribute.DisableCertificateValidation, this.options.Value.DisableCertificateValidation);
 
-            IRabbitMQService service = configProvider.GetService(resolvedConnectionString, resolvedDisableCertificateValidation);
+            IRabbitMQService service = this.configProvider.GetService(resolvedConnectionString, resolvedDisableCertificateValidation);
 
             return service.Model;
         }

--- a/extension/WebJobs.Extensions.RabbitMQ/Bindings/RabbitMQClientBuilder.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Bindings/RabbitMQClientBuilder.cs
@@ -9,13 +9,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     internal class RabbitMQClientBuilder : IConverter<RabbitMQAttribute, IModel>
     {
-        private readonly RabbitMQExtensionConfigProvider _configProvider;
-        private readonly IOptions<RabbitMQOptions> _options;
+        private readonly RabbitMQExtensionConfigProvider configProvider;
+        private readonly IOptions<RabbitMQOptions> options;
 
         public RabbitMQClientBuilder(RabbitMQExtensionConfigProvider configProvider, IOptions<RabbitMQOptions> options)
         {
-            _configProvider = configProvider;
-            _options = options;
+            this.configProvider = configProvider;
+            this.options = options;
         }
 
         public IModel Convert(RabbitMQAttribute attribute)
@@ -30,10 +30,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 throw new ArgumentNullException(nameof(attribute));
             }
 
-            string resolvedConnectionString = Utility.FirstOrDefault(attribute.ConnectionStringSetting, _options.Value.ConnectionString);
-            bool resolvedDisableCertificateValidation = Utility.FirstOrDefault(attribute.DisableCertificateValidation, _options.Value.DisableCertificateValidation);
+            string resolvedConnectionString = Utility.FirstOrDefault(attribute.ConnectionStringSetting, options.Value.ConnectionString);
+            bool resolvedDisableCertificateValidation = Utility.FirstOrDefault(attribute.DisableCertificateValidation, options.Value.DisableCertificateValidation);
 
-            IRabbitMQService service = _configProvider.GetService(resolvedConnectionString, resolvedDisableCertificateValidation);
+            IRabbitMQService service = configProvider.GetService(resolvedConnectionString, resolvedDisableCertificateValidation);
 
             return service.Model;
         }

--- a/extension/WebJobs.Extensions.RabbitMQ/Config/RabbitMQExtensionConfigProvider.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Config/RabbitMQExtensionConfigProvider.cs
@@ -11,28 +11,27 @@ using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using RabbitMQ.Client;
 
 namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     [Extension("RabbitMQ")]
     internal class RabbitMQExtensionConfigProvider : IExtensionConfigProvider
     {
-        private readonly IOptions<RabbitMQOptions> _options;
-        private readonly INameResolver _nameResolver;
-        private readonly IRabbitMQServiceFactory _rabbitMQServiceFactory;
-        private readonly ILogger _logger;
-        private readonly IConfiguration _configuration;
-        private readonly ConcurrentDictionary<string, IRabbitMQService> _connectionParametersToService;
+        private readonly IOptions<RabbitMQOptions> options;
+        private readonly INameResolver nameResolver;
+        private readonly IRabbitMQServiceFactory rabbitMQServiceFactory;
+        private readonly ILogger logger;
+        private readonly IConfiguration configuration;
+        private readonly ConcurrentDictionary<string, IRabbitMQService> connectionParametersToService;
 
         public RabbitMQExtensionConfigProvider(IOptions<RabbitMQOptions> options, INameResolver nameResolver, IRabbitMQServiceFactory rabbitMQServiceFactory, ILoggerFactory loggerFactory, IConfiguration configuration)
         {
-            _options = options;
-            _nameResolver = nameResolver;
-            _rabbitMQServiceFactory = rabbitMQServiceFactory;
-            _logger = loggerFactory?.CreateLogger(LogCategories.CreateTriggerCategory("RabbitMQ"));
-            _configuration = configuration;
-            _connectionParametersToService = new ConcurrentDictionary<string, IRabbitMQService>();
+            this.options = options;
+            this.nameResolver = nameResolver;
+            this.rabbitMQServiceFactory = rabbitMQServiceFactory;
+            logger = loggerFactory?.CreateLogger(LogCategories.CreateTriggerCategory("RabbitMQ"));
+            this.configuration = configuration;
+            connectionParametersToService = new ConcurrentDictionary<string, IRabbitMQService>();
         }
 
         public void Initialize(ExtensionConfigContext context)
@@ -43,11 +42,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             FluentBindingRule<RabbitMQAttribute> rule = context.AddBindingRule<RabbitMQAttribute>();
 #pragma warning restore 0618
 
-            rule.BindToCollector<ReadOnlyMemory<byte>>((attr) =>
+            rule.BindToCollector((attr) =>
             {
-                return new RabbitMQAsyncCollector(CreateContext(attr), _logger);
+                return new RabbitMQAsyncCollector(CreateContext(attr), logger);
             });
-            rule.BindToInput<IModel>(new RabbitMQClientBuilder(this, _options));
+            rule.BindToInput(new RabbitMQClientBuilder(this, options));
             rule.AddConverter<string, ReadOnlyMemory<byte>>(arg => Encoding.UTF8.GetBytes(arg));
             rule.AddConverter<byte[], ReadOnlyMemory<byte>>(arg => arg);
             rule.AddOpenConverter<OpenType.Poco, ReadOnlyMemory<byte>>(typeof(PocoToBytesConverter<>));
@@ -58,18 +57,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
             // More details about why the BindToTrigger was chosen instead of BindToTrigger<BasicDeliverEventArgs> detailed here https://github.com/Azure/azure-functions-rabbitmq-extension/issues/110
             triggerRule.BindToTrigger(new RabbitMQTriggerAttributeBindingProvider(
-                    _nameResolver,
+                    nameResolver,
                     this,
-                    _logger,
-                    _options,
-                    _configuration));
+                    logger,
+                    options,
+                    configuration));
         }
 
         internal RabbitMQContext CreateContext(RabbitMQAttribute attribute)
         {
-            string connectionString = Utility.FirstOrDefault(attribute.ConnectionStringSetting, _options.Value.ConnectionString);
-            string queueName = Utility.FirstOrDefault(attribute.QueueName, _options.Value.QueueName);
-            bool disableCertificateValidation = Utility.FirstOrDefault(attribute.DisableCertificateValidation, _options.Value.DisableCertificateValidation);
+            string connectionString = Utility.FirstOrDefault(attribute.ConnectionStringSetting, options.Value.ConnectionString);
+            string queueName = Utility.FirstOrDefault(attribute.QueueName, options.Value.QueueName);
+            bool disableCertificateValidation = Utility.FirstOrDefault(attribute.DisableCertificateValidation, options.Value.DisableCertificateValidation);
 
             var resolvedAttribute = new RabbitMQAttribute
             {
@@ -91,7 +90,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         {
             string[] keyArray = { connectionString, queueName, disableCertificateValidation.ToString() };
             string key = string.Join(",", keyArray);
-            return _connectionParametersToService.GetOrAdd(key, _ => _rabbitMQServiceFactory.CreateService(connectionString, queueName, disableCertificateValidation));
+            return connectionParametersToService.GetOrAdd(key, _ => rabbitMQServiceFactory.CreateService(connectionString, queueName, disableCertificateValidation));
         }
 
         // Overloaded method used only for getting the RabbitMQ client
@@ -99,7 +98,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         {
             string[] keyArray = { connectionString, disableCertificateValidation.ToString() };
             string key = string.Join(",", keyArray);
-            return _connectionParametersToService.GetOrAdd(key, _ => _rabbitMQServiceFactory.CreateService(connectionString, disableCertificateValidation));
+            return connectionParametersToService.GetOrAdd(key, _ => rabbitMQServiceFactory.CreateService(connectionString, disableCertificateValidation));
         }
     }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ/Config/RabbitMQOptions.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Config/RabbitMQOptions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         public string ConnectionString { get; set; }
 
         /// <summary>
-        /// Gets the RabbitMQ queue name.
+        /// Gets or sets the RabbitMQ queue name.
         /// </summary>
         public string QueueName { get; set; }
 
@@ -37,9 +37,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         {
             var options = new JObject
             {
-                [nameof(QueueName)] = QueueName,
-                [nameof(PrefetchCount)] = PrefetchCount,
-                [nameof(DisableCertificateValidation)] = DisableCertificateValidation,
+                [nameof(this.QueueName)] = this.QueueName,
+                [nameof(this.PrefetchCount)] = this.PrefetchCount,
+                [nameof(this.DisableCertificateValidation)] = this.DisableCertificateValidation,
             };
 
             return options.ToString(Formatting.Indented);

--- a/extension/WebJobs.Extensions.RabbitMQ/Services/RabbitMQService.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Services/RabbitMQService.cs
@@ -21,18 +21,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 connectionFactory.Ssl.AcceptablePolicyErrors |= SslPolicyErrors.RemoteCertificateChainErrors;
             }
 
-            Model = connectionFactory.CreateConnection().CreateModel();
-            PublishBatchLock = new object();
+            this.Model = connectionFactory.CreateConnection().CreateModel();
+            this.PublishBatchLock = new object();
         }
 
         public RabbitMQService(string connectionString, string queueName, bool disableCertificateValidation)
             : this(connectionString, disableCertificateValidation)
         {
-            RabbitMQModel = new RabbitMQModel(Model);
+            this.RabbitMQModel = new RabbitMQModel(this.Model);
             _ = queueName ?? throw new ArgumentNullException(nameof(queueName));
 
-            Model.QueueDeclarePassive(queueName); // Throws exception if queue doesn't exist
-            BasicPublishBatch = Model.CreateBasicPublishBatch();
+            this.Model.QueueDeclarePassive(queueName); // Throws exception if queue doesn't exist
+            this.BasicPublishBatch = this.Model.CreateBasicPublishBatch();
         }
 
         public IRabbitMQModel RabbitMQModel { get; }
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         // Typically called after a flush
         public void ResetPublishBatch()
         {
-            BasicPublishBatch = Model.CreateBasicPublishBatch();
+            this.BasicPublishBatch = this.Model.CreateBasicPublishBatch();
         }
     }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/BasicDeliverEventArgsValueProvider.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/BasicDeliverEventArgsValueProvider.cs
@@ -12,11 +12,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     public class BasicDeliverEventArgsValueProvider : IValueProvider
     {
-        private readonly BasicDeliverEventArgs _input;
+        private readonly BasicDeliverEventArgs input;
 
         public BasicDeliverEventArgsValueProvider(BasicDeliverEventArgs input, Type destinationType)
         {
-            _input = input;
+            this.input = input;
             Type = destinationType;
         }
 
@@ -26,15 +26,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         {
             if (Type.Equals(typeof(BasicDeliverEventArgs)))
             {
-                return Task.FromResult<object>(_input);
+                return Task.FromResult<object>(input);
             }
             else if (Type.Equals(typeof(ReadOnlyMemory<byte>)))
             {
-                return Task.FromResult<object>(_input.Body);
+                return Task.FromResult<object>(input.Body);
             }
             else if (Type.Equals(typeof(byte[])))
             {
-                return Task.FromResult<object>(_input.Body.ToArray());
+                return Task.FromResult<object>(input.Body.ToArray());
             }
 
             string inputValue = ToInvokeString();
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
         public string ToInvokeString()
         {
-            return Encoding.UTF8.GetString(_input.Body.ToArray());
+            return Encoding.UTF8.GetString(input.Body.ToArray());
         }
     }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/BasicDeliverEventArgsValueProvider.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/BasicDeliverEventArgsValueProvider.cs
@@ -17,28 +17,28 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
         public BasicDeliverEventArgsValueProvider(BasicDeliverEventArgs input, Type destinationType)
         {
             this.input = input;
-            Type = destinationType;
+            this.Type = destinationType;
         }
 
         public Type Type { get; }
 
         public Task<object> GetValueAsync()
         {
-            if (Type.Equals(typeof(BasicDeliverEventArgs)))
+            if (this.Type.Equals(typeof(BasicDeliverEventArgs)))
             {
-                return Task.FromResult<object>(input);
+                return Task.FromResult<object>(this.input);
             }
-            else if (Type.Equals(typeof(ReadOnlyMemory<byte>)))
+            else if (this.Type.Equals(typeof(ReadOnlyMemory<byte>)))
             {
-                return Task.FromResult<object>(input.Body);
+                return Task.FromResult<object>(this.input.Body);
             }
-            else if (Type.Equals(typeof(byte[])))
+            else if (this.Type.Equals(typeof(byte[])))
             {
-                return Task.FromResult<object>(input.Body.ToArray());
+                return Task.FromResult<object>(this.input.Body.ToArray());
             }
 
-            string inputValue = ToInvokeString();
-            if (Type.Equals(typeof(string)))
+            string inputValue = this.ToInvokeString();
+            if (this.Type.Equals(typeof(string)))
             {
                 return Task.FromResult<object>(inputValue);
             }
@@ -46,12 +46,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             {
                 try
                 {
-                    return Task.FromResult(JsonConvert.DeserializeObject(inputValue, Type));
+                    return Task.FromResult(JsonConvert.DeserializeObject(inputValue, this.Type));
                 }
                 catch (JsonException e)
                 {
                     // Give useful error if object in queue is not deserialized properly.
-                    string msg = $@"Binding parameters to complex objects (such as '{Type.Name}') uses Json.NET serialization. The JSON parser failed: {e.Message}";
+                    string msg = $@"Binding parameters to complex objects (such as '{this.Type.Name}') uses Json.NET serialization. The JSON parser failed: {e.Message}";
                     throw new InvalidOperationException(msg, e);
                 }
             }
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
         public string ToInvokeString()
         {
-            return Encoding.UTF8.GetString(input.Body.ToArray());
+            return Encoding.UTF8.GetString(this.input.Body.ToArray());
         }
     }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQModel.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQModel.cs
@@ -11,69 +11,69 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
     {
         public RabbitMQModel(IModel model)
         {
-            Model = model;
+            this.Model = model;
         }
 
         public IModel Model { get; }
 
         public IBasicPublishBatch CreateBasicPublishBatch()
         {
-            return Model.CreateBasicPublishBatch();
+            return this.Model.CreateBasicPublishBatch();
         }
 
         public QueueDeclareOk QueueDeclarePassive(string queue)
         {
-            return Model.QueueDeclarePassive(queue);
+            return this.Model.QueueDeclarePassive(queue);
         }
 
         public QueueDeclareOk QueueDeclare(string queue, bool durable, bool exclusive, bool autoDelete, IDictionary<string, object> arguments)
         {
-            return Model.QueueDeclare(queue, durable, exclusive, autoDelete, arguments);
+            return this.Model.QueueDeclare(queue, durable, exclusive, autoDelete, arguments);
         }
 
         public void QueueBind(string queue, string exchange, string routingKey, IDictionary<string, object> arguments)
         {
-            Model.QueueBind(queue, exchange, routingKey, arguments);
+            this.Model.QueueBind(queue, exchange, routingKey, arguments);
         }
 
         public void BasicQos(uint prefetchSize, ushort prefetchCount, bool global)
         {
-            Model.BasicQos(prefetchSize, prefetchCount, global);
+            this.Model.BasicQos(prefetchSize, prefetchCount, global);
         }
 
         public string BasicConsume(string queue, bool autoAck, IBasicConsumer consumer)
         {
-            return Model.BasicConsume(queue, autoAck, consumer);
+            return this.Model.BasicConsume(queue, autoAck, consumer);
         }
 
         public void BasicAck(ulong deliveryTag, bool multiple)
         {
-            Model.BasicAck(deliveryTag, multiple);
+            this.Model.BasicAck(deliveryTag, multiple);
         }
 
         public void BasicReject(ulong deliveryTag, bool requeue)
         {
-            Model.BasicReject(deliveryTag, requeue);
+            this.Model.BasicReject(deliveryTag, requeue);
         }
 
         public void BasicPublish(string exchange, string routingKey, IBasicProperties basicProperties, ReadOnlyMemory<byte> body)
         {
-            Model.BasicPublish(exchange, routingKey, basicProperties, body);
+            this.Model.BasicPublish(exchange, routingKey, basicProperties, body);
         }
 
         public void BasicCancel(string consumerTag)
         {
-            Model.BasicCancel(consumerTag);
+            this.Model.BasicCancel(consumerTag);
         }
 
         public void ExchangeDeclare(string exchange, string exchangeType)
         {
-            Model.ExchangeDeclare(exchange, exchangeType);
+            this.Model.ExchangeDeclare(exchange, exchangeType);
         }
 
         public void Close()
         {
-            Model.Close();
+            this.Model.Close();
         }
     }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerAttribute.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerAttribute.cs
@@ -14,12 +14,12 @@ namespace Microsoft.Azure.WebJobs
     public sealed class RabbitMQTriggerAttribute : Attribute
     {
         /// <summary>
-        /// Constructs a new instance.
+        /// Initializes a new instance of the <see cref="RabbitMQTriggerAttribute"/> class.
         /// </summary>
         /// <param name="queueName">RabbitMQ queue name.</param>
         public RabbitMQTriggerAttribute(string queueName)
         {
-            QueueName = queueName;
+            this.QueueName = queueName;
         }
 
         /// <summary>

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
@@ -14,11 +14,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     internal class RabbitMQTriggerAttributeBindingProvider : ITriggerBindingProvider
     {
-        private readonly INameResolver _nameResolver;
-        private readonly RabbitMQExtensionConfigProvider _provider;
-        private readonly ILogger _logger;
-        private readonly IOptions<RabbitMQOptions> _options;
-        private readonly IConfiguration _configuration;
+        private readonly INameResolver nameResolver;
+        private readonly RabbitMQExtensionConfigProvider provider;
+        private readonly ILogger logger;
+        private readonly IOptions<RabbitMQOptions> options;
+        private readonly IConfiguration configuration;
 
         public RabbitMQTriggerAttributeBindingProvider(
             INameResolver nameResolver,
@@ -27,11 +27,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             IOptions<RabbitMQOptions> options,
             IConfiguration configuration)
         {
-            _nameResolver = nameResolver ?? throw new ArgumentNullException(nameof(nameResolver));
-            _provider = provider ?? throw new ArgumentNullException(nameof(provider));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _options = options;
-            _configuration = configuration;
+            this.nameResolver = nameResolver ?? throw new ArgumentNullException(nameof(nameResolver));
+            this.provider = provider ?? throw new ArgumentNullException(nameof(provider));
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            this.options = options;
+            this.configuration = configuration;
         }
 
         public Task<ITriggerBinding> TryCreateAsync(TriggerBindingProviderContext context)
@@ -46,18 +46,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 return Task.FromResult<ITriggerBinding>(null);
             }
 
-            string connectionString = Utility.ResolveConnectionString(attribute.ConnectionStringSetting, _options.Value.ConnectionString, _configuration);
+            string connectionString = Utility.ResolveConnectionString(attribute.ConnectionStringSetting, options.Value.ConnectionString, configuration);
             string queueName = Resolve(attribute.QueueName) ?? throw new InvalidOperationException("RabbitMQ queue name is missing");
-            bool disableCertificateValidation = attribute.DisableCertificateValidation || _options.Value.DisableCertificateValidation;
+            bool disableCertificateValidation = attribute.DisableCertificateValidation || options.Value.DisableCertificateValidation;
 
-            IRabbitMQService service = _provider.GetService(connectionString, queueName, disableCertificateValidation);
+            IRabbitMQService service = provider.GetService(connectionString, queueName, disableCertificateValidation);
 
-            return Task.FromResult<ITriggerBinding>(new RabbitMQTriggerBinding(service, queueName, _logger, parameter.ParameterType, _options.Value.PrefetchCount));
+            return Task.FromResult<ITriggerBinding>(new RabbitMQTriggerBinding(service, queueName, logger, parameter.ParameterType, options.Value.PrefetchCount));
         }
 
         private string Resolve(string name)
         {
-            return _nameResolver.ResolveWholeString(name) ?? name;
+            return nameResolver.ResolveWholeString(name) ?? name;
         }
     }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
@@ -46,18 +46,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
                 return Task.FromResult<ITriggerBinding>(null);
             }
 
-            string connectionString = Utility.ResolveConnectionString(attribute.ConnectionStringSetting, options.Value.ConnectionString, configuration);
-            string queueName = Resolve(attribute.QueueName) ?? throw new InvalidOperationException("RabbitMQ queue name is missing");
-            bool disableCertificateValidation = attribute.DisableCertificateValidation || options.Value.DisableCertificateValidation;
+            string connectionString = Utility.ResolveConnectionString(attribute.ConnectionStringSetting, this.options.Value.ConnectionString, this.configuration);
+            string queueName = this.Resolve(attribute.QueueName) ?? throw new InvalidOperationException("RabbitMQ queue name is missing");
+            bool disableCertificateValidation = attribute.DisableCertificateValidation || this.options.Value.DisableCertificateValidation;
 
-            IRabbitMQService service = provider.GetService(connectionString, queueName, disableCertificateValidation);
+            IRabbitMQService service = this.provider.GetService(connectionString, queueName, disableCertificateValidation);
 
-            return Task.FromResult<ITriggerBinding>(new RabbitMQTriggerBinding(service, queueName, logger, parameter.ParameterType, options.Value.PrefetchCount));
+            return Task.FromResult<ITriggerBinding>(new RabbitMQTriggerBinding(service, queueName, this.logger, parameter.ParameterType, this.options.Value.PrefetchCount));
         }
 
         private string Resolve(string name)
         {
-            return nameResolver.ResolveWholeString(name) ?? name;
+            return this.nameResolver.ResolveWholeString(name) ?? name;
         }
     }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerBinding.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerBinding.cs
@@ -16,19 +16,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 {
     internal class RabbitMQTriggerBinding : ITriggerBinding
     {
-        private readonly IRabbitMQService _service;
-        private readonly ILogger _logger;
-        private readonly Type _parameterType;
-        private readonly string _queueName;
-        private readonly ushort _prefetchCount;
+        private readonly IRabbitMQService service;
+        private readonly ILogger logger;
+        private readonly Type parameterType;
+        private readonly string queueName;
+        private readonly ushort prefetchCount;
 
         public RabbitMQTriggerBinding(IRabbitMQService service, string queueName, ILogger logger, Type parameterType, ushort prefetchCount)
         {
-            _service = service;
-            _queueName = queueName;
-            _logger = logger;
-            _parameterType = parameterType;
-            _prefetchCount = prefetchCount;
+            this.service = service;
+            this.queueName = queueName;
+            this.logger = logger;
+            this.parameterType = parameterType;
+            this.prefetchCount = prefetchCount;
             BindingDataContract = CreateBindingDataContract();
         }
 
@@ -41,21 +41,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             var message = (BasicDeliverEventArgs)value;
             IReadOnlyDictionary<string, object> bindingData = CreateBindingData(message);
 
-            return Task.FromResult<ITriggerData>(new TriggerData(new BasicDeliverEventArgsValueProvider(message, _parameterType), bindingData));
+            return Task.FromResult<ITriggerData>(new TriggerData(new BasicDeliverEventArgsValueProvider(message, parameterType), bindingData));
         }
 
         public Task<IListener> CreateListenerAsync(ListenerFactoryContext context)
         {
             _ = context ?? throw new ArgumentNullException(nameof(context));
 
-            return Task.FromResult<IListener>(new RabbitMQListener(context.Executor, _service, _queueName, _logger, context.Descriptor, _prefetchCount));
+            return Task.FromResult<IListener>(new RabbitMQListener(context.Executor, service, queueName, logger, context.Descriptor, prefetchCount));
         }
 
         public ParameterDescriptor ToParameterDescriptor()
         {
             return new RabbitMQTriggerParameterDescriptor
             {
-                QueueName = _queueName,
+                QueueName = queueName,
             };
         }
 

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerBinding.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerBinding.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             this.logger = logger;
             this.parameterType = parameterType;
             this.prefetchCount = prefetchCount;
-            BindingDataContract = CreateBindingDataContract();
+            this.BindingDataContract = CreateBindingDataContract();
         }
 
         public Type TriggerValueType => typeof(BasicDeliverEventArgs);
@@ -41,21 +41,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             var message = (BasicDeliverEventArgs)value;
             IReadOnlyDictionary<string, object> bindingData = CreateBindingData(message);
 
-            return Task.FromResult<ITriggerData>(new TriggerData(new BasicDeliverEventArgsValueProvider(message, parameterType), bindingData));
+            return Task.FromResult<ITriggerData>(new TriggerData(new BasicDeliverEventArgsValueProvider(message, this.parameterType), bindingData));
         }
 
         public Task<IListener> CreateListenerAsync(ListenerFactoryContext context)
         {
             _ = context ?? throw new ArgumentNullException(nameof(context));
 
-            return Task.FromResult<IListener>(new RabbitMQListener(context.Executor, service, queueName, logger, context.Descriptor, prefetchCount));
+            return Task.FromResult<IListener>(new RabbitMQListener(context.Executor, this.service, this.queueName, this.logger, context.Descriptor, this.prefetchCount));
         }
 
         public ParameterDescriptor ToParameterDescriptor()
         {
             return new RabbitMQTriggerParameterDescriptor
             {
-                QueueName = queueName,
+                QueueName = this.queueName,
             };
         }
 

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerParameterDescriptor.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerParameterDescriptor.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
         public override string GetTriggerReason(IDictionary<string, string> arguments)
         {
-            return $"RabbitMQ message detected from queue: {QueueName} at {DateTime.Now}";
+            return $"RabbitMQ message detected from queue: {this.QueueName} at {DateTime.Now}";
         }
     }
 }

--- a/extension/stylecop.json
+++ b/extension/stylecop.json
@@ -1,10 +1,4 @@
 ﻿{
-  // ACTION REQUIRED: This file was automatically added to your project, but it
-  // will not take effect until additional steps are taken to enable it. See the
-  // following page for additional information:
-  //
-  // https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/EnableConfiguration.md
-
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
@@ -16,9 +10,6 @@
       "documentExposedElements": false,
       "documentPrivateElements": false,
       "documentPrivateFields": false
-    },
-    "namingRules": {
-      "allowedHungarianPrefixes": [ "_" ]
     },
     "orderingRules": {
       "usingDirectivesPlacement": "outsideNamespace"


### PR DESCRIPTION
Adhering to default StyleCop recommendations i.e., using `this.` in front of the instance variables. This way is more consistent since otherwise we use variables with names like `_varName` for private instance fields, and names like `VarName` for public and private static fields and public instance properties. When referencing one of these variables in rest of the class, having `this.` prefixed makes it clear to the reader whether instance or static or local variable is being accessed. In that case, the underscore prefix becomes irrelevant. Similar justification can be found in StyleCop documentation [here](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1309.md#rule-description) and [here](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1101.md#rule-description).

 