### PR TITLE
Fix exceptions when connection string is not specified

### DIFF
--- a/extension/WebJobs.Extensions.RabbitMQ/Utility.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Utility.cs
@@ -22,17 +22,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
 
         internal static string ResolveConnectionString(string attributeConnectionStringKey, string optionsConnectionString, IConfiguration configuration)
         {
-            try
+            // Is the connection-string key present in the binding attribute?
+            if (attributeConnectionStringKey != null)
             {
                 string resolvedString = configuration.GetConnectionStringOrSetting(attributeConnectionStringKey);
+
+                // Is there a value associated with the key?
                 if (!string.IsNullOrEmpty(resolvedString))
                 {
                     return resolvedString;
                 }
-            }
-            catch (InvalidOperationException)
-            {
-                // Do nothing.
             }
 
             return optionsConnectionString;


### PR DESCRIPTION
If the connection-string setting name is not explicitly specified by user in RabbitMQ trigger binding, the method `ResolveConnectionString` internally throws `ArgumentNullException`. To fix the StyleCop errors, I had switched catching of generic exception `Exception` to `InvalidOperationException` which caused this regression. I am unable to remember why this specific exception was chosen but it should be by going through the code of `GetConnectionStringOrSetting`.

Instead of going back to generic `Exception`, I found it more apt to directly check if the connection string key is not specified explicitly by the user. WebJobs SDK code also calls `GetConnectionStringOrSetting` at few places but does not handle any exception. Note that the problem is only with trigger bindings; it does not affect the output binding functionality.