### PR TITLE
Added distributed tracing instrumentation

### DIFF
--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQListener.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQListener.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             else
             {
                 activity = ActivitySource.StartActivity("Trigger", ActivityKind.Server);
-ea.BasicProperties.Headers ??= new Dictionary<string, object>();
+                ea.BasicProperties.Headers ??= new Dictionary<string, object>();
                 byte[] traceParentIdInBytes = Encoding.Default.GetBytes(activity.Id);
                 ea.BasicProperties.Headers["traceparent"] = traceParentIdInBytes;
             }

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQListener.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQListener.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             else
             {
                 activity = ActivitySource.StartActivity("Trigger", ActivityKind.Server);
-                if (ea.BasicProperties.Headers == null)
+ea.BasicProperties.Headers ??= new Dictionary<string, object>();
                 {
                     ea.BasicProperties.Headers = new Dictionary<string, object>();
                 }

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQListener.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQListener.cs
@@ -164,14 +164,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             if (ea.BasicProperties.Headers != null && ea.BasicProperties.Headers.ContainsKey("traceparent"))
             {
                 byte[] traceParentIdInBytes = ea.BasicProperties.Headers["traceparent"] as byte[];
-                string traceparentId = Encoding.Default.GetString(traceParentIdInBytes);
+                string traceparentId = Encoding.UTF8.GetString(traceParentIdInBytes);
                 activity = ActivitySource.StartActivity("Trigger", ActivityKind.Consumer, traceparentId);
             }
             else
             {
                 activity = ActivitySource.StartActivity("Trigger", ActivityKind.Server);
                 ea.BasicProperties.Headers ??= new Dictionary<string, object>();
-                byte[] traceParentIdInBytes = Encoding.Default.GetBytes(activity.Id);
+                byte[] traceParentIdInBytes = Encoding.UTF8.GetBytes(activity.Id);
                 ea.BasicProperties.Headers["traceparent"] = traceParentIdInBytes;
             }
 

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQListener.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQListener.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             }
             else
             {
-                activity = ActivitySource.StartActivity("Trigger", ActivityKind.Server);
+                activity = ActivitySource.StartActivity("Trigger", ActivityKind.Consumer);
                 ea.BasicProperties.Headers ??= new Dictionary<string, object>();
                 byte[] traceParentIdInBytes = Encoding.UTF8.GetBytes(activity.Id);
                 ea.BasicProperties.Headers["traceparent"] = traceParentIdInBytes;

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQListener.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQListener.cs
@@ -171,10 +171,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ
             {
                 activity = ActivitySource.StartActivity("Trigger", ActivityKind.Server);
 ea.BasicProperties.Headers ??= new Dictionary<string, object>();
-                {
-                    ea.BasicProperties.Headers = new Dictionary<string, object>();
-                }
-
                 byte[] traceParentIdInBytes = Encoding.Default.GetBytes(activity.Id);
                 ea.BasicProperties.Headers["traceparent"] = traceParentIdInBytes;
             }

--- a/extension/WebJobs.Extensions.RabbitMQ/WebJobs.Extensions.RabbitMQ.csproj
+++ b/extension/WebJobs.Extensions.RabbitMQ/WebJobs.Extensions.RabbitMQ.csproj
@@ -58,6 +58,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
     <PackageReference Include="System.Json" Version="4.7.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Added distributed tracing instrumentation. Users can now collect the distributed trace telemetry to diagnose application issues when needed. 

Message producers need to pass "traceparent" id in headers of message while publishing the message to have distributed tracing, otherwise created activity will be treated as root activity.
Please note: TraceParentId needs to be in [W3C trace context](https://www.w3.org/TR/trace-context/) format.

Since distributed tracing is not fully supported yet, users need to add a file (say starup.cs) in root folder of function app and do openTelemetry configuration.

Follow these resources for more details:
 [Adding distributed tracing instrumentation](https://docs.microsoft.com/en-us/dotnet/core/diagnostics/distributed-tracing-instrumentation-walkthroughs)
[openTelemetry Configuration .NET](https://opentelemetry.io/docs/instrumentation/net/getting-started/)


Sample code for startup.cs file:
![image](https://user-images.githubusercontent.com/106390596/178955155-05e936d0-2b09-4b10-b760-c3a88c8c9fa1.png)
