### PR TITLE
Add `dataType` property to output / trigger annotation for Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The following attributes are common to both RabbitMQ trigger and output bindings
 | `ConnectionStringSetting` | string | The setting name for RabbitMQ connection URI. An example setting value would be `amqp://user:pass@host:10000/vhost`. |
 | `QueueName` | string | The RabbitMQ queue name. |
 | `DisableCertificateValidation` | boolean | Indicates whether certificate validation should be disabled. Not recommended for production. Does not apply when SSL is disabled. |
+| `dataType` | string | DataType of the message. "" by default as String, "binary" for byte[]|
 
 ## Further Reading
 

--- a/java-library/src/main/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQOutput.java
+++ b/java-library/src/main/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQOutput.java
@@ -55,4 +55,14 @@ public @interface RabbitMQOutput {
      * production. Does not apply when SSL is disabled.
      */
     boolean disableCertificateValidation() default false;
+
+    /**
+     * <p>Defines how Functions runtime should treat the parameter value. Possible values are:</p>
+     * <ul>
+     *     <li>"" or string: treat it as a string whose value is serialized from the parameter</li>
+     *     <li>binary: treat it as a binary data whose value comes from for example OutputBinding&lt;byte[]&lt;</li>
+     * </ul>
+     * @return The dataType which will be used by the Functions runtime.
+     */
+    String dataType() default "";
 }

--- a/java-library/src/main/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQTrigger.java
+++ b/java-library/src/main/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQTrigger.java
@@ -54,4 +54,15 @@ public @interface RabbitMQTrigger {
      * production. Does not apply when SSL is disabled.
      */
     boolean disableCertificateValidation() default false;
+
+    /**
+     * <p>Defines how Functions runtime should treat the parameter value. Possible values are:</p>
+     * <ul>
+     *     <li>"": get the value as a string, and try to deserialize to actual parameter type like POJO</li>
+     *     <li>string: always get the value as a string</li>
+     *     <li>binary: get the value as a binary data, and try to deserialize to actual parameter type byte[]</li>
+     * </ul>
+     * @return The dataType which will be used by the Functions runtime.
+     */
+    String dataType() default "";
 }

--- a/java-library/src/test/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQOutputTests.java
+++ b/java-library/src/test/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQOutputTests.java
@@ -18,10 +18,12 @@ public class RabbitMQOutputTests {
         EasyMock.expect(outputMock.queueName()).andReturn("dummyQueueName");
         EasyMock.expect(outputMock.connectionStringSetting()).andReturn("dummyConnectionStringSetting");
         EasyMock.expect(outputMock.disableCertificateValidation()).andReturn(true);
+        EasyMock.expect(outputMock.dataType()).andReturn("string");
         EasyMock.replay(outputMock);
 
         Assert.assertEquals("dummyQueueName", outputMock.queueName());
         Assert.assertEquals("dummyConnectionStringSetting", outputMock.connectionStringSetting());
         Assert.assertEquals(true, outputMock.disableCertificateValidation());
+        Assert.assertEquals("string", outputMock.dataType());
     }
 }

--- a/java-library/src/test/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQTriggerTests.java
+++ b/java-library/src/test/java/com/microsoft/azure/functions/rabbitmq/annotation/RabbitMQTriggerTests.java
@@ -18,10 +18,12 @@ public class RabbitMQTriggerTests {
         EasyMock.expect(triggerMock.queueName()).andReturn("dummyQueueName");
         EasyMock.expect(triggerMock.connectionStringSetting()).andReturn("dummyConnectionStringSetting");
         EasyMock.expect(triggerMock.disableCertificateValidation()).andReturn(true);
+        EasyMock.expect(triggerMock.dataType()).andReturn("string");
         EasyMock.replay(triggerMock);
 
         Assert.assertEquals("dummyQueueName", triggerMock.queueName());
         Assert.assertEquals("dummyConnectionStringSetting", triggerMock.connectionStringSetting());
         Assert.assertEquals(true, triggerMock.disableCertificateValidation());
+        Assert.assertEquals("string", triggerMock.dataType());
     }
 }


### PR DESCRIPTION
Fixes a problem where the output / trigger annotation for Java library is missing the `dataType` property, which prevents it from handling binary data well.


### ex. Kafka output / trigger annotation

- https://github.com/Azure/azure-functions-java-library/blob/6e8d6f72bf40eeef25ab8d2b4babc2f8239b0bf8/src/main/java/com/microsoft/azure/functions/annotation/KafkaOutput.java#L67
- https://github.com/Azure/azure-functions-java-library/blob/6e8d6f72bf40eeef25ab8d2b4babc2f8239b0bf8/src/main/java/com/microsoft/azure/functions/annotation/KafkaTrigger.java#L100