### PR TITLE
Fix Maven goals and options

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -165,18 +165,20 @@ jobs:
         displayName: Extract version # e.g. 1.2.3
         condition: and(succeeded(), eq(variables.isTagTriggered, 'True'))
 
+        # A combination of --batch-mode and --define=org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+        # options prevents spurious logging about downloading of Maven packages.
       - task: Maven@3
         displayName: Set library version
         inputs:
           mavenPomFile: java-library\pom.xml
           goals: versions:set
-          options: --define=newVersion=$(version)
+          options: --batch-mode --define=newVersion=$(version) --define=org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn --update-snapshots
 
       - task: Maven@3
         displayName: Build library
         inputs:
           mavenPomFile: java-library\pom.xml
-          options: --batch-mode --define=gpg.skip --define=org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn --update-snapshots
+          options: --batch-mode --define=org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn --update-snapshots
 
       - powershell: |
           $prefix = 'azure-functions-java-library-rabbitmq-$(version)'

--- a/java-library/mvnBuild.bat
+++ b/java-library/mvnBuild.bat
@@ -1,1 +1,1 @@
-mvn clean install -U -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B -Dgpg.skip
+mvn clean package "--define=org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" --update-snapshots


### PR DESCRIPTION
Updated Maven commands based on discussion with SQL extension team.

- Added new definitions in `versions:set` step. Reduced number of lines logged from [~8400](https://dev.azure.com/azfunc/Azure%20Functions/_build/results?buildId=104523&view=logs&j=a86360a3-af4e-5bfd-90ce-5c8e0454606f&t=10ef54d6-422e-513f-616c-aa972be8751c) to [~400](https://dev.azure.com/azfunc/Azure%20Functions/_build/results?buildId=106032&view=logs&j=a86360a3-af4e-5bfd-90ce-5c8e0454606f&t=10ef54d6-422e-513f-616c-aa972be8751c).
- Removed definition of `gpg:skip` as there is no signing happening anyway in `package` step.
- Modified the `mvn` goals and options in the `mvnBuild.bat` file.