### PR TITLE
Run build pipeline on Linux agents

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,27 +14,35 @@ trigger:
       - v*.*.*
 
 variables:
-  isTagTriggered: ${{ startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}
+  # It is a release build if it is triggered by pushing a tag.
+  isReleaseBuild: ${{ startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}
+
+  ${{ if eq(variables.isReleaseBuild, 'True') }}:
+    agentOSes: Windows
+  ${{ else }}:
+    agentOSes: Windows,Linux
+
   prefix: $[format('0.{0:yyyy}.{0:MMdd}', pipeline.startTime)]
   version: $[format('{0}.{1}', variables.prefix, counter(variables.prefix, 1))] # e.g. 0.2001.0203.4
   fileVersion: $[variables.version]
 
-  ${{ if eq(variables.isTagTriggered, 'True') }}:
-    vmImages: 'Windows:MMS2019TLS,Linux:MMSUbuntu20.04TLS'
-  ${{ else }}:
-    vmImages: 'Windows:windows-latest,Linux:ubuntu-latest'
-
 jobs:
-  - ${{ each vmImage in split(variables.vmImages, ',') }}:
-      - job: buildExtension${{ split(vmImage, ':')[0] }}
-        displayName: WebJobs Extension (${{ split(vmImage, ':')[0] }})
+  - ${{ each agentOS in split(variables.agentOSes, ',') }}:
+      - job: buildExtension${{ agentOS }}
+        displayName: WebJobs Extension (${{ agentOS }})
 
         pool:
-          name: 1ES-Hosted-AzFunc
-          vmImage: ${{ split(vmImage, ':')[1] }}
+          ${{ if eq(variables.isReleaseBuild, 'True') }}:
+            name: 1ES-Hosted-AzFunc
+            demands:
+              - ImageOverride -equals MMS2022TLS
+          ${{ elseif eq(agentOS, 'Windows') }}:
+            vmImage: windows-latest
+          ${{ elseif eq(agentOS, 'Linux') }}:
+            vmImage: ubuntu-latest
 
         steps:
-          - ${{ if and(eq(split(vmImage, ':')[0], 'Windows'), eq(variables.isTagTriggered, 'True')) }}:
+          - ${{ if eq(variables.isReleaseBuild, 'True') }}:
             - powershell: | # Allow tags matching v1.2.3 and v1.2.3-xyz1
                 $found = '$(Build.SourceBranchName)' | Select-String -Pattern '^v(((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))(?:-\w+)?)$'
                 if (-not $found) {
@@ -46,6 +54,7 @@ jobs:
 
               displayName: Extract version # e.g. 1.2.3
 
+          - ${{ if eq(variables.isReleaseBuild, 'True') }}:
             # .NET Core 2.1 SDK is required by ESRP Code Signing tasks.
             - task: UseDotNet@2
               displayName: Acquire .NET Core 2.1 SDK
@@ -75,7 +84,7 @@ jobs:
               workingDirectory: extension
               arguments: --configuration Debug
 
-          - ${{ if and(eq(split(vmImage, ':')[0], 'Windows'), eq(variables.isTagTriggered, 'True')) }}:
+          - ${{ if eq(variables.isReleaseBuild, 'True') }}:
             - task: EsrpCodeSigning@1
               displayName: Sign extension assembly
               inputs:
@@ -107,6 +116,7 @@ jobs:
                     }
                   ]
 
+          - ${{ if eq(variables.isReleaseBuild, 'True') }}:
             - task: DotNetCoreCLI@2
               displayName: Pack extension
               inputs:
@@ -119,6 +129,7 @@ jobs:
                 includesymbols: true
                 verbosityPack: minimal
 
+          - ${{ if eq(variables.isReleaseBuild, 'True') }}:
             - task: EsrpCodeSigning@1
               displayName: Sign extension package
               inputs:
@@ -144,6 +155,7 @@ jobs:
                       }
                   ]
 
+          - ${{ if eq(variables.isReleaseBuild, 'True') }}:
             - task: DeleteFiles@1
               displayName: Cleanup staging directory
               inputs:
@@ -151,6 +163,7 @@ jobs:
                 # contents: '!(Microsoft.Azure.WebJobs.Extensions.RabbitMQ.*.nupkg)'
                 contents: CodeSignSummary-*.md
 
+          - ${{ if eq(variables.isReleaseBuild, 'True') }}:
             - task: ManifestGeneratorTask@0
               displayName: Generate SBOM manifest
               inputs:
@@ -158,19 +171,26 @@ jobs:
                 packageName: Azure Functions RabbitMQ Extension
                 packageVersion: $(version)
 
+          - ${{ if eq(variables.isReleaseBuild, 'True') }}:
             - publish: $(Build.ArtifactStagingDirectory)
               displayName: Publish extension package
               artifact: drop-extension
 
-      - job: buildJavaLibrary${{ split(vmImage, ':')[0] }}
-        displayName: Java library (${{ split(vmImage, ':')[0] }})
+      - job: buildJavaLibrary${{ agentOS }}
+        displayName: Java Library (${{ agentOS }})
 
         pool:
-          name: 1ES-Hosted-AzFunc
-          vmImage: ${{ split(vmImage, ':')[1] }}
+          ${{ if eq(variables.isReleaseBuild, 'True') }}:
+            name: 1ES-Hosted-AzFunc
+            demands:
+              - ImageOverride -equals MMS2022TLS
+          ${{ elseif eq(agentOS, 'Windows') }}:
+            vmImage: windows-latest
+          ${{ elseif eq(agentOS, 'Linux') }}:
+            vmImage: ubuntu-latest
 
         steps:
-          - ${{ if and(eq(split(vmImage, ':')[0], 'Windows'), eq(variables.isTagTriggered, 'True')) }}:
+          - ${{ if eq(variables.isReleaseBuild, 'True') }}:
             - powershell: | # Allow tags matching v1.2.3 and v1.2.3-xyz1
                 $found = '$(Build.SourceBranchName)' | Select-String -Pattern '^v((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-\w+)?)$'
                 if (-not $found) {
@@ -196,7 +216,7 @@ jobs:
               mavenPomFile: java-library/pom.xml
               options: --batch-mode --define=org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn --update-snapshots
 
-          - ${{ if and(eq(split(vmImage, ':')[0], 'Windows'), eq(variables.isTagTriggered, 'True')) }}:
+          - ${{ if eq(variables.isReleaseBuild, 'True') }}:
             - powershell: |
                 $prefix = 'azure-functions-java-library-rabbitmq-$(version)'
                 $source = 'java-library'
@@ -210,6 +230,7 @@ jobs:
 
               displayName: Copy output files
 
+          - ${{ if eq(variables.isReleaseBuild, 'True') }}:
             - task: ManifestGeneratorTask@0
               displayName: Generate SBOM manifest
               inputs:
@@ -217,6 +238,7 @@ jobs:
                 packageName: Azure Functions RabbitMQ Java Bindings
                 packageVersion: $(version)
 
+          - ${{ if eq(variables.isReleaseBuild, 'True') }}:
             - publish: $(Build.ArtifactStagingDirectory)
               displayName: Publish library package
               artifact: drop-java-library

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,11 +14,15 @@ trigger:
       - v*.*.*
 
 variables:
-  vmImages: 'Windows:MMS2019TLS,Linux:MMSUbuntu20.04TLS'
   isTagTriggered: ${{ startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}
   prefix: $[format('0.{0:yyyy}.{0:MMdd}', pipeline.startTime)]
   version: $[format('{0}.{1}', variables.prefix, counter(variables.prefix, 1))] # e.g. 0.2001.0203.4
   fileVersion: $[variables.version]
+
+  ${{ if eq(variables.isTagTriggered, 'True') }}:
+    vmImages: 'Windows:MMS2019TLS,Linux:MMSUbuntu20.04TLS'
+  ${{ else }}:
+    vmImages: 'Windows:windows-latest,Linux:ubuntu-latest'
 
 jobs:
   - ${{ each vmImage in split(variables.vmImages, ',') }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,194 +14,205 @@ trigger:
       - v*.*.*
 
 variables:
-  isTagTriggered: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
+  vmImages: 'Windows:MMS2019TLS,Linux:MMSUbuntu20.04TLS'
+  isTagTriggered: ${{ startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}
   prefix: $[format('0.{0:yyyy}.{0:MMdd}', pipeline.startTime)]
   version: $[format('{0}.{1}', variables.prefix, counter(variables.prefix, 1))] # e.g. 0.2001.0203.4
   fileVersion: $[variables.version]
 
-pool:
-  name: 1ES-Hosted-AzFunc
-  demands:
-    - ImageOverride -equals MMS2022TLS
-
 jobs:
-  - job: buildExtension
-    displayName: WebJobs extension
-    steps:
-      - powershell: | # Allow tags matching v1.2.3 and v1.2.3-xyz1
-          $found = '$(Build.SourceBranchName)' | Select-String -Pattern '^v(((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))(?:-\w+)?)$'
-          if (-not $found) {
-            Write-Error "Found unexpected tag name: $(Build.SourceBranchName)."
-            exit 1
-          }
-          Write-Host "##vso[task.setvariable variable=version]$($found.Matches.Groups[1].Value)"
-          Write-Host "##vso[task.setvariable variable=fileVersion]$($found.Matches.Groups[2].Value)"
-        displayName: Extract version # e.g. 1.2.3
-        condition: and(succeeded(), eq(variables.isTagTriggered, 'True'))
+  - ${{ each vmImage in split(variables.vmImages, ',') }}:
+      - job: buildExtension${{ split(vmImage, ':')[0] }}
+        displayName: WebJobs Extension (${{ split(vmImage, ':')[0] }})
 
-      - task: UseDotNet@2
-        displayName: Acquire .NET SDK
-        inputs:
-          packageType: sdk
-          version: 6.x
-          performMultiLevelLookup: true
+        pool:
+          name: 1ES-Hosted-AzFunc
+          vmImage: ${{ split(vmImage, ':')[1] }}
 
-      - task: DotNetCoreCLI@2
-        displayName: Build solution
-        inputs:
-          command: build
-          workingDirectory: extension
-          arguments: --configuration Release -property:Version=$(fileVersion) -property:CommitHash=$(Build.SourceVersion)
-
-      - task: DotNetCoreCLI@2
-        displayName: Test extension
-        inputs:
-          command: test
-          workingDirectory: extension
-          arguments: --configuration Debug
-
-      - task: EsrpCodeSigning@1
-        displayName: Sign extension assembly
-        condition: and(succeeded(), eq(variables.isTagTriggered, 'True'))
-        inputs:
-          connectedServiceName: ESRP Service
-          folderPath: extension\WebJobs.Extensions.RabbitMQ\bin\Release\netstandard2.0
-          pattern: Microsoft.Azure.WebJobs.Extensions.RabbitMQ.dll
-          signConfigType: inlineSignParams
-          inlineOperation: |
-            [
-              {
-                "KeyCode": "CP-230012",
-                "OperationCode": "SigntoolSign",
-                "Parameters": {
-                  "OpusName": "Microsoft",
-                  "OpusInfo": "http://www.microsoft.com",
-                  "FileDigest": "/fd \"SHA256\"",
-                  "PageHash": "/NPH",
-                  "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                },
-                "ToolName": "sign",
-                "ToolVersion": "1.0"
-              },
-              {
-                "KeyCode": "CP-230012",
-                "OperationCode": "SigntoolVerify",
-                "Parameters": {},
-                "ToolName": "sign",
-                "ToolVersion": "1.0"
-              }
-            ]
-
-      - task: DotNetCoreCLI@2
-        displayName: Pack extension
-        condition: and(succeeded(), eq(variables.isTagTriggered, 'True'))
-        inputs:
-          command: pack
-          searchPatternPack: extension\WebJobs.Extensions.RabbitMQ\WebJobs.Extensions.RabbitMQ.csproj
-          configurationToPack: Release
-          buildProperties: Version=$(version);CommitHash=$(Build.SourceVersion)
-          outputDir: $(Build.ArtifactStagingDirectory)\$(version)
-          nobuild: true
-          includesymbols: true
-          verbosityPack: minimal
-
-      - task: EsrpCodeSigning@1
-        displayName: Sign extension package
-        condition: and(succeeded(), eq(variables.isTagTriggered, 'True'))
-        inputs:
-          connectedServiceName: ESRP Service
-          folderPath: $(Build.ArtifactStagingDirectory)\$(version)
-          pattern: Microsoft.Azure.WebJobs.Extensions.RabbitMQ.*.nupkg
-          signConfigType: inlineSignParams
-          inlineOperation: |
-            [
-                {
-                  "KeyCode": "CP-401405",
-                  "OperationCode": "NuGetSign",
-                  "Parameters": {},
-                  "ToolName": "sign",
-                  "ToolVersion": "1.0"
-                },
-                {
-                  "KeyCode": "CP-401405",
-                  "OperationCode": "NuGetVerify",
-                  "Parameters": {},
-                  "ToolName": "sign",
-                  "ToolVersion": "1.0"
+        steps:
+          - ${{ if and(eq(split(vmImage, ':')[0], 'Windows'), eq(variables.isTagTriggered, 'True')) }}:
+            - powershell: | # Allow tags matching v1.2.3 and v1.2.3-xyz1
+                $found = '$(Build.SourceBranchName)' | Select-String -Pattern '^v(((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))(?:-\w+)?)$'
+                if (-not $found) {
+                  Write-Error "Found unexpected tag name: $(Build.SourceBranchName)."
+                  exit 1
                 }
-            ]
+                Write-Host "##vso[task.setvariable variable=version]$($found.Matches.Groups[1].Value)"
+                Write-Host "##vso[task.setvariable variable=fileVersion]$($found.Matches.Groups[2].Value)"
 
-      - task: DeleteFiles@1
-        displayName: Cleanup staging directory
-        condition: and(succeeded(), eq(variables.isTagTriggered, 'True'))
-        inputs:
-          sourceFolder: $(Build.ArtifactStagingDirectory)\$(version)
-          # contents: '!(Microsoft.Azure.WebJobs.Extensions.RabbitMQ.*.nupkg)'
-          contents: CodeSignSummary-*.md
+              displayName: Extract version # e.g. 1.2.3
 
-      - task: ManifestGeneratorTask@0
-        displayName: Generate SBOM manifest
-        condition: and(succeeded(), eq(variables.isTagTriggered, 'True'))
-        inputs:
-          buildDropPath: $(Build.ArtifactStagingDirectory)\$(version)
-          packageName: Azure Functions RabbitMQ Extension
-          packageVersion: $(version)
+            # .NET Core 2.1 SDK is required by ESRP Code Signing tasks.
+            - task: UseDotNet@2
+              displayName: Acquire .NET Core 2.1 SDK
+              inputs:
+                packageType: sdk
+                version: 2.1.x
+                performMultiLevelLookup: true
 
-      - publish: $(Build.ArtifactStagingDirectory)
-        displayName: Publish extension package
-        condition: and(succeeded(), eq(variables.isTagTriggered, 'True'))
-        artifact: drop-extension
+          - task: UseDotNet@2
+            displayName: Acquire .NET 7.0 SDK
+            inputs:
+              packageType: sdk
+              version: 7.0.x
+              performMultiLevelLookup: true
 
-  - job: buildJavaLibrary
-    displayName: Java library
-    steps:
-      - powershell: | # Allow tags matching v1.2.3 and v1.2.3-xyz1
-          $found = '$(Build.SourceBranchName)' | Select-String -Pattern '^v((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-\w+)?)$'
-          if (-not $found) {
-            Write-Error "Found unexpected tag name: $(Build.SourceBranchName)."
-            exit 1
-          }
-          Write-Host "##vso[task.setvariable variable=version]$($found.Matches.Groups[1].Value)"
-        displayName: Extract version # e.g. 1.2.3
-        condition: and(succeeded(), eq(variables.isTagTriggered, 'True'))
+          - task: DotNetCoreCLI@2
+            displayName: Build solution
+            inputs:
+              command: build
+              workingDirectory: extension
+              arguments: --configuration Release -property:Version=$(fileVersion) -property:CommitHash=$(Build.SourceVersion)
 
-        # A combination of --batch-mode and --define=org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-        # options prevents spurious logging about downloading of Maven packages.
-      - task: Maven@3
-        displayName: Set library version
-        inputs:
-          mavenPomFile: java-library\pom.xml
-          goals: versions:set
-          options: --batch-mode --define=newVersion=$(version) --define=org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn --update-snapshots
+          - task: DotNetCoreCLI@2
+            displayName: Test extension
+            inputs:
+              command: test
+              workingDirectory: extension
+              arguments: --configuration Debug
 
-      - task: Maven@3
-        displayName: Build library
-        inputs:
-          mavenPomFile: java-library\pom.xml
-          options: --batch-mode --define=org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn --update-snapshots
+          - ${{ if and(eq(split(vmImage, ':')[0], 'Windows'), eq(variables.isTagTriggered, 'True')) }}:
+            - task: EsrpCodeSigning@1
+              displayName: Sign extension assembly
+              inputs:
+                connectedServiceName: ESRP Service
+                folderPath: extension/WebJobs.Extensions.RabbitMQ/bin/Release/netstandard2.0
+                pattern: Microsoft.Azure.WebJobs.Extensions.RabbitMQ.dll
+                signConfigType: inlineSignParams
+                inlineOperation: |
+                  [
+                    {
+                      "KeyCode": "CP-230012",
+                      "OperationCode": "SigntoolSign",
+                      "Parameters": {
+                        "OpusName": "Microsoft",
+                        "OpusInfo": "http://www.microsoft.com",
+                        "FileDigest": "/fd \"SHA256\"",
+                        "PageHash": "/NPH",
+                        "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                      },
+                      "ToolName": "sign",
+                      "ToolVersion": "1.0"
+                    },
+                    {
+                      "KeyCode": "CP-230012",
+                      "OperationCode": "SigntoolVerify",
+                      "Parameters": {},
+                      "ToolName": "sign",
+                      "ToolVersion": "1.0"
+                    }
+                  ]
 
-      - powershell: |
-          $prefix = 'azure-functions-java-library-rabbitmq-$(version)'
-          $source = 'java-library'
-          $destination = '$(Build.ArtifactStagingDirectory)\$(version)'
+            - task: DotNetCoreCLI@2
+              displayName: Pack extension
+              inputs:
+                command: pack
+                searchPatternPack: extension/WebJobs.Extensions.RabbitMQ/WebJobs.Extensions.RabbitMQ.csproj
+                configurationToPack: Release
+                buildProperties: Version=$(version);CommitHash=$(Build.SourceVersion)
+                outputDir: $(Build.ArtifactStagingDirectory)/$(version)
+                nobuild: true
+                includesymbols: true
+                verbosityPack: minimal
 
-          New-Item $destination -ItemType Directory
-          Copy-Item "$source\pom.xml" "$destination\$prefix.pom"
-          Copy-Item "$source\target\$prefix.jar" "$destination\$prefix.jar"
-          Copy-Item "$source\target\$prefix-javadoc.jar" "$destination\$prefix-javadoc.jar"
-          Copy-Item "$source\target\$prefix-sources.jar" "$destination\$prefix-sources.jar"
-        displayName: Copy output files
-        condition: and(succeeded(), eq(variables.isTagTriggered, 'True'))
+            - task: EsrpCodeSigning@1
+              displayName: Sign extension package
+              inputs:
+                connectedServiceName: ESRP Service
+                folderPath: $(Build.ArtifactStagingDirectory)/$(version)
+                pattern: Microsoft.Azure.WebJobs.Extensions.RabbitMQ.*.nupkg
+                signConfigType: inlineSignParams
+                inlineOperation: |
+                  [
+                      {
+                        "KeyCode": "CP-401405",
+                        "OperationCode": "NuGetSign",
+                        "Parameters": {},
+                        "ToolName": "sign",
+                        "ToolVersion": "1.0"
+                      },
+                      {
+                        "KeyCode": "CP-401405",
+                        "OperationCode": "NuGetVerify",
+                        "Parameters": {},
+                        "ToolName": "sign",
+                        "ToolVersion": "1.0"
+                      }
+                  ]
 
-      - task: ManifestGeneratorTask@0
-        displayName: Generate SBOM manifest
-        condition: and(succeeded(), eq(variables.isTagTriggered, 'True'))
-        inputs:
-          buildDropPath: $(Build.ArtifactStagingDirectory)\$(version)
-          packageName: Azure Functions RabbitMQ Java Bindings
-          packageVersion: $(version)
+            - task: DeleteFiles@1
+              displayName: Cleanup staging directory
+              inputs:
+                sourceFolder: $(Build.ArtifactStagingDirectory)/$(version)
+                # contents: '!(Microsoft.Azure.WebJobs.Extensions.RabbitMQ.*.nupkg)'
+                contents: CodeSignSummary-*.md
 
-      - publish: $(Build.ArtifactStagingDirectory)
-        displayName: Publish library package
-        condition: and(succeeded(), eq(variables.isTagTriggered, 'True'))
-        artifact: drop-java-library
+            - task: ManifestGeneratorTask@0
+              displayName: Generate SBOM manifest
+              inputs:
+                buildDropPath: $(Build.ArtifactStagingDirectory)/$(version)
+                packageName: Azure Functions RabbitMQ Extension
+                packageVersion: $(version)
+
+            - publish: $(Build.ArtifactStagingDirectory)
+              displayName: Publish extension package
+              artifact: drop-extension
+
+      - job: buildJavaLibrary${{ split(vmImage, ':')[0] }}
+        displayName: Java library (${{ split(vmImage, ':')[0] }})
+
+        pool:
+          name: 1ES-Hosted-AzFunc
+          vmImage: ${{ split(vmImage, ':')[1] }}
+
+        steps:
+          - ${{ if and(eq(split(vmImage, ':')[0], 'Windows'), eq(variables.isTagTriggered, 'True')) }}:
+            - powershell: | # Allow tags matching v1.2.3 and v1.2.3-xyz1
+                $found = '$(Build.SourceBranchName)' | Select-String -Pattern '^v((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-\w+)?)$'
+                if (-not $found) {
+                  Write-Error "Found unexpected tag name: $(Build.SourceBranchName)."
+                  exit 1
+                }
+                Write-Host "##vso[task.setvariable variable=version]$($found.Matches.Groups[1].Value)"
+
+              displayName: Extract version # e.g. 1.2.3
+
+            # A combination of --batch-mode and --define=org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+            # options prevents spurious logging about downloading of Maven packages.
+          - task: Maven@3
+            displayName: Set library version
+            inputs:
+              mavenPomFile: java-library/pom.xml
+              goals: versions:set
+              options: --batch-mode --define=newVersion=$(version) --define=org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn --update-snapshots
+
+          - task: Maven@3
+            displayName: Build library
+            inputs:
+              mavenPomFile: java-library/pom.xml
+              options: --batch-mode --define=org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn --update-snapshots
+
+          - ${{ if and(eq(split(vmImage, ':')[0], 'Windows'), eq(variables.isTagTriggered, 'True')) }}:
+            - powershell: |
+                $prefix = 'azure-functions-java-library-rabbitmq-$(version)'
+                $source = 'java-library'
+                $destination = '$(Build.ArtifactStagingDirectory)/$(version)'
+
+                New-Item $destination -ItemType Directory
+                Copy-Item "$source/pom.xml" "$destination/$prefix.pom"
+                Copy-Item "$source/target/$prefix.jar" "$destination/$prefix.jar"
+                Copy-Item "$source/target/$prefix-javadoc.jar" "$destination/$prefix-javadoc.jar"
+                Copy-Item "$source/target/$prefix-sources.jar" "$destination/$prefix-sources.jar"
+
+              displayName: Copy output files
+
+            - task: ManifestGeneratorTask@0
+              displayName: Generate SBOM manifest
+              inputs:
+                buildDropPath: $(Build.ArtifactStagingDirectory)/$(version)
+                packageName: Azure Functions RabbitMQ Java Bindings
+                packageVersion: $(version)
+
+            - publish: $(Build.ArtifactStagingDirectory)
+              displayName: Publish library package
+              artifact: drop-java-library

--- a/extension/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.Samples/RabbitMQSamples.cs
@@ -118,7 +118,7 @@ internal static class RabbitMQSamples
         logger.LogInformation($"RabbitMQ output binding function sent message: {outputMessage}");
     }
 
-    public class TestClass
+    public sealed class TestClass
     {
         public int X { get; set; }
 

--- a/extension/WebJobs.Extensions.RabbitMQ.Samples/WebJobs.Extensions.RabbitMQ.Samples.csproj
+++ b/extension/WebJobs.Extensions.RabbitMQ.Samples/WebJobs.Extensions.RabbitMQ.Samples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Samples</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Samples</RootNamespace>
     <LangVersion>latest</LangVersion>
@@ -29,7 +29,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="4.0.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/extension/WebJobs.Extensions.RabbitMQ.Tests/BasicDeliverEventArgsValueProviderTests.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.Tests/BasicDeliverEventArgsValueProviderTests.cs
@@ -112,10 +112,10 @@ public class BasicDeliverEventArgsValueProviderTests
         var args = new BasicDeliverEventArgs("tag", 1, false, string.Empty, "queue", null, objJsonBytes);
         var testValueProvider = new BasicDeliverEventArgsValueProvider(args, typeof(TestClass));
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => testValueProvider.GetValueAsync());
+        await Assert.ThrowsAsync<InvalidOperationException>(testValueProvider.GetValueAsync);
     }
 
-    private class TestClass
+    private sealed class TestClass
     {
         public int X { get; set; }
 

--- a/extension/WebJobs.Extensions.RabbitMQ.Tests/PocoToBytesConverterTests.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.Tests/PocoToBytesConverterTests.cs
@@ -30,7 +30,7 @@ public class PocoToBytesConverterTests
         Assert.Throws<ArgumentNullException>(() => converter.Convert(null));
     }
 
-    private class TestClass
+    private sealed class TestClass
     {
         public int X { get; set; }
 

--- a/extension/WebJobs.Extensions.RabbitMQ.Tests/WebJobs.Extensions.RabbitMQ.Tests.csproj
+++ b/extension/WebJobs.Extensions.RabbitMQ.Tests/WebJobs.Extensions.RabbitMQ.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.RabbitMQ.Tests</RootNamespace>
     <LangVersion>latest</LangVersion>
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="RabbitMQ.Client" Version="6.4.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">

--- a/extension/WebJobs.Extensions.RabbitMQ/WebJobs.Extensions.RabbitMQ.csproj
+++ b/extension/WebJobs.Extensions.RabbitMQ/WebJobs.Extensions.RabbitMQ.csproj
@@ -48,17 +48,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.33" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="RabbitMQ.Client" Version="6.4.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
     <PackageReference Include="System.Json" Version="4.7.1" />
   </ItemGroup>
 


### PR DESCRIPTION
**What's changed**
- Updated build pipeline to build extension and Java library on both Windows and Linux agents.
- Updated .NET SDK to 7.0.
- Upgraded all referenced libraries.
- Removed package reference of `Microsoft.CodeAnalysis.NetAnalyzer`. It is not required as it gets shipped as part of .NET 7.0 SDK.
- Fixed code to comply with the updated CodeAnalysis rules.
- Used [Azure Pipelines](https://dev.azure.com/azfunc/Azure%20Functions/_settings/agentqueues?queueId=38&view=jobs) agent pool to speed-up regular builds, and [Executive Order compliant build servers](https://dev.azure.com/azfunc/Azure%20Functions/_settings/agentqueues?queueId=85&view=jobs) for release builds.

**Test pipeline runs**
- [Continuous Integration build](https://dev.azure.com/azfunc/Azure%20Functions/_build/results?buildId=106456)
- [Release build](https://dev.azure.com/azfunc/Azure%20Functions/_build/results?buildId=106457)