### PR TITLE
Tracing: add useful tags to Trigger spans

### DIFF
--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQListener.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQListener.cs
@@ -107,6 +107,9 @@ internal sealed class RabbitMQListener : IListener, IScaleMonitor<RabbitMQTrigge
         async Task ReceivedHandler(object model, BasicDeliverEventArgs args)
         {
             using Activity activity = RabbitMQActivitySource.StartActivity(args.BasicProperties);
+            activity?.AddTag("amqp.queue", this.queue);
+            activity?.AddTag("amqp.channel", this.channel);
+            activity?.AddTag("amqp.bodySize", args.Body.Length);
 
             var input = new TriggeredFunctionData() { TriggerValue = args };
 
@@ -118,6 +121,7 @@ internal sealed class RabbitMQListener : IListener, IScaleMonitor<RabbitMQTrigge
                 args.BasicProperties.Headers ??= new Dictionary<string, object>();
                 args.BasicProperties.Headers.TryGetValue(RequeueCountHeaderName, out object headerValue);
                 int requeueCount = Convert.ToInt32(headerValue, CultureInfo.InvariantCulture) + 1;
+                activity?.AddTag("amqp.requeueCount", requeueCount);
 
                 if (requeueCount >= 5)
                 {


### PR DESCRIPTION
Spans generated from this library don't have any tags to identify the source queue and other useful information. With this PR 4 tags are included:

- source queue.
- amqp channel.
- body size
- requeue count header