### PR TITLE
support manualAck attribute for in-proc

### DIFF
--- a/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQClientBuilderTests.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQClientBuilderTests.cs
@@ -22,13 +22,13 @@ public class RabbitMQClientBuilderTests
         var options = new OptionsWrapper<RabbitMQOptions>(new RabbitMQOptions());
         var mockServiceFactory = new Mock<IRabbitMQServiceFactory>();
         var config = new RabbitMQExtensionConfigProvider(options, new Mock<INameResolver>().Object, mockServiceFactory.Object, new LoggerFactory(), EmptyConfig, DrainModeManager);
-        mockServiceFactory.Setup(m => m.CreateService(It.IsAny<string>(), false)).Returns(new Mock<IRabbitMQService>().Object);
+        mockServiceFactory.Setup(m => m.CreateService(It.IsAny<string>(), false, It.IsAny<ILogger>())).Returns(new Mock<IRabbitMQService>().Object);
         RabbitMQAttribute attr = GetTestAttribute();
 
         var clientBuilder = new RabbitMQClientBuilder(config, options);
-        IModel model = clientBuilder.Convert(attr);
+        IRabbitMQService service = clientBuilder.Convert(attr);
 
-        mockServiceFactory.Verify(m => m.CreateService(It.IsAny<string>(), false), Times.Exactly(1));
+        mockServiceFactory.Verify(m => m.CreateService(It.IsAny<string>(), false, It.IsAny<ILogger>()), Times.Exactly(1));
     }
 
     [Fact]
@@ -36,17 +36,17 @@ public class RabbitMQClientBuilderTests
     {
         var options = new OptionsWrapper<RabbitMQOptions>(new RabbitMQOptions());
         var mockServiceFactory = new Mock<IRabbitMQServiceFactory>();
-        mockServiceFactory.SetupSequence(m => m.CreateService(It.IsAny<string>(), false))
+        mockServiceFactory.SetupSequence(m => m.CreateService(It.IsAny<string>(), false, It.IsAny<ILogger>()))
             .Returns(GetRabbitMQService());
         var config = new RabbitMQExtensionConfigProvider(options, new Mock<INameResolver>().Object, mockServiceFactory.Object, new LoggerFactory(), EmptyConfig, DrainModeManager);
         RabbitMQAttribute attr = GetTestAttribute();
 
         var clientBuilder = new RabbitMQClientBuilder(config, options);
 
-        IModel model = clientBuilder.Convert(attr);
-        IModel model2 = clientBuilder.Convert(attr);
+        IRabbitMQService service = clientBuilder.Convert(attr);
+        IRabbitMQService service2 = clientBuilder.Convert(attr);
 
-        Assert.Equal(model, model2);
+        Assert.Equal(service, service2);
     }
 
     private static RabbitMQAttribute GetTestAttribute()
@@ -60,7 +60,6 @@ public class RabbitMQClientBuilderTests
     private static IRabbitMQService GetRabbitMQService()
     {
         var mockService = new Mock<IRabbitMQService>();
-        mockService.Setup(a => a.Model).Returns(new Mock<IModel>().Object);
         return mockService.Object;
     }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQExtensionConfigProviderTests.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQExtensionConfigProviderTests.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -18,11 +19,11 @@ public class RabbitMQExtensionConfigProviderTests
         var rabbitmqServiceFactory = new Mock<IRabbitMQServiceFactory>();
 
         rabbitmqServiceFactory
-            .SetupSequence(a => a.CreateService(It.IsAny<string>(), It.IsAny<string>(), false))
+            .SetupSequence(a => a.CreateService(It.IsAny<string>(), It.IsAny<string>(), false, It.IsAny<ILogger>()))
             .Returns(new Mock<IRabbitMQService>().Object);
 
         rabbitmqServiceFactory
-            .SetupSequence(a => a.CreateService(It.IsAny<string>(), false))
+            .SetupSequence(a => a.CreateService(It.IsAny<string>(), false, It.IsAny<ILogger>()))
             .Returns(new Mock<IRabbitMQService>().Object);
 
         var extensionConfigProvider = new RabbitMQExtensionConfigProvider(

--- a/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQTriggerBindingTests.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQTriggerBindingTests.cs
@@ -115,12 +115,12 @@ public class RabbitMQTriggerBindingTests
         await listener.StartAsync(CancellationToken.None);
 
         // Find the Consumer instance passed to RabbitMQService.Consume method
-        IInvocation basicConsumeInvocation = mockservice.Invocations
+        IInvocation consumeInvocation = mockservice.Invocations
             .FirstOrDefault(invocation => invocation.Method.Name == "Consume");
 
-        Assert.NotNull(basicConsumeInvocation);
+        Assert.NotNull(consumeInvocation);
 
-        var consumer = basicConsumeInvocation.Arguments[2] as AsyncEventingBasicConsumer;
+        var consumer = consumeInvocation.Arguments[2] as AsyncEventingBasicConsumer;
         Assert.NotNull(consumer);
 
         // Simulate message delivery

--- a/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQTriggerBindingTests.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQTriggerBindingTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Moq;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using Xunit;
@@ -23,6 +24,7 @@ public class RabbitMQTriggerBindingTests
             ["RoutingKey"] = typeof(string),
             ["BasicProperties"] = typeof(IBasicProperties),
             ["Body"] = typeof(ReadOnlyMemory<byte>),
+            ["RabbitMQMessageActions"] = typeof(RabbitMQMessageActions),
         };
 
         IReadOnlyDictionary<string, Type> actualContract = RabbitMQTriggerBinding.CreateBindingDataContract();
@@ -44,6 +46,7 @@ public class RabbitMQTriggerBindingTests
 
         ReadOnlyMemory<byte> body = buffer;
         var eventArgs = new BasicDeliverEventArgs("ConsumerName", deliveryTag, false, "n/a", "QueueName", null, body);
+        var messageActions = new RabbitMQMessageActions(Mock.Of<IModel>());
 
         var data = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
         {
@@ -54,13 +57,42 @@ public class RabbitMQTriggerBindingTests
             ["Body"] = body,
             ["Exchange"] = eventArgs.Exchange,
             ["BasicProperties"] = eventArgs.BasicProperties,
+            ["RabbitMQMessageActions"] = messageActions,
         };
 
-        IReadOnlyDictionary<string, object> actualContract = RabbitMQTriggerBinding.CreateBindingData(eventArgs);
+        IReadOnlyDictionary<string, object> actualContract = RabbitMQTriggerBinding.CreateBindingData(eventArgs, messageActions);
 
         foreach (KeyValuePair<string, object> item in actualContract)
         {
             Assert.Equal(data[item.Key], item.Value);
         }
+    }
+
+    [Fact]
+    public void RabbitMQTriggerAttribute_ManualAck_DefaultsToFalse()
+    {
+        var attribute = new RabbitMQTriggerAttribute("test-queue");
+        bool manualAck = attribute.ManualAck;
+        Assert.False(manualAck, "ManualAck should default to false.");
+    }
+
+    [Fact]
+    public void RabbitMQTriggerBinding_CreateBindingData_IncludesRabbitMQMessageActions()
+    {
+        ulong deliveryTag = 1;
+
+        var rand = new Random();
+        byte[] buffer = new byte[10];
+        rand.NextBytes(buffer);
+
+        ReadOnlyMemory<byte> body = buffer;
+        var eventArgs = new BasicDeliverEventArgs("ConsumerName", deliveryTag, false, "n/a", "QueueName", null, body);
+        var messageActions = new RabbitMQMessageActions(Mock.Of<IModel>());
+
+        IReadOnlyDictionary<string, object> bindingData = RabbitMQTriggerBinding.CreateBindingData(eventArgs, messageActions);
+
+        // Assert
+        Assert.True(bindingData.ContainsKey("RabbitMQMessageActions"), "Binding data should include RabbitMQMessageActions.");
+        Assert.Equal(messageActions, bindingData["RabbitMQMessageActions"]);
     }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQTriggerBindingTests.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQTriggerBindingTests.cs
@@ -3,6 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Extensions.Logging;
 using Moq;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
@@ -94,5 +100,73 @@ public class RabbitMQTriggerBindingTests
         // Assert
         Assert.True(bindingData.ContainsKey("MessageActions"), "Binding data should include MessageActions.");
         Assert.Equal(messageActions, bindingData["MessageActions"]);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task RabbitMQTrigger_ManualAck_BasicAckBehavior(bool manualAck)
+    {
+        // Arrange
+        var mockChannel = new Mock<IModel>();
+        var mockExecutor = new Mock<ITriggeredFunctionExecutor>();
+        var mockLogger = new Mock<ILogger>();
+        var mockDrainModeManager = new Mock<IDrainModeManager>();
+        var mockBasicProperties = new Mock<IBasicProperties>();
+
+        // Simulate successful function execution
+        mockExecutor
+            .Setup(executor => executor.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FunctionResult(true));
+
+        var listener = new RabbitMQListener(
+            mockChannel.Object,
+            mockExecutor.Object,
+            mockLogger.Object,
+            functionId: "test-function",
+            queueName: "test-queue",
+            manualAck: manualAck,
+            prefetchCount: 10,
+            drainModeManager: mockDrainModeManager.Object);
+
+        var eventArgs = new BasicDeliverEventArgs
+        {
+            DeliveryTag = 1,
+            Body = new ReadOnlyMemory<byte>([0x01, 0x02, 0x03]),
+            BasicProperties = mockBasicProperties.Object,
+        };
+
+        // Act
+        await listener.StartAsync(CancellationToken.None);
+
+        // Find the IBasicConsumer passed to BasicConsume
+        IInvocation basicConsumeInvocation = mockChannel.Invocations
+            .FirstOrDefault(invocation => invocation.Method.Name == "BasicConsume");
+
+        Assert.NotNull(basicConsumeInvocation);
+
+        // The third argument is the consumer
+        var consumer = basicConsumeInvocation.Arguments[6] as AsyncEventingBasicConsumer;
+        Assert.NotNull(consumer);
+
+        // Simulate message delivery
+        await consumer.HandleBasicDeliver(
+            consumerTag: "ctag",
+            deliveryTag: eventArgs.DeliveryTag,
+            redelivered: false,
+            exchange: string.Empty,
+            routingKey: string.Empty,
+            properties: eventArgs.BasicProperties,
+            body: eventArgs.Body.ToArray());
+
+        // Assert
+        if (manualAck)
+        {
+            mockChannel.Verify(channel => channel.BasicAck(It.IsAny<ulong>(), It.IsAny<bool>()), Times.Never, "BasicAck should not be called when ManualAck is true.");
+        }
+        else
+        {
+            mockChannel.Verify(channel => channel.BasicAck(It.IsAny<ulong>(), It.IsAny<bool>()), Times.AtLeastOnce, "BasicAck should be called when ManualAck is false.");
+        }
     }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQTriggerBindingTests.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQTriggerBindingTests.cs
@@ -145,7 +145,6 @@ public class RabbitMQTriggerBindingTests
 
         Assert.NotNull(basicConsumeInvocation);
 
-        // The third argument is the consumer
         var consumer = basicConsumeInvocation.Arguments[6] as AsyncEventingBasicConsumer;
         Assert.NotNull(consumer);
 

--- a/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQTriggerBindingTests.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQTriggerBindingTests.cs
@@ -52,7 +52,7 @@ public class RabbitMQTriggerBindingTests
 
         ReadOnlyMemory<byte> body = buffer;
         var eventArgs = new BasicDeliverEventArgs("ConsumerName", deliveryTag, false, "n/a", "QueueName", null, body);
-        var messageActions = new RabbitMQMessageActions(Mock.Of<IRabbitMQService>());
+        var messageActions = new RabbitMQMessageActions(Mock.Of<IRabbitMQService>(), eventArgs);
 
         var data = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
         {
@@ -136,11 +136,11 @@ public class RabbitMQTriggerBindingTests
         // Assert
         if (disableAck)
         {
-            mockservice.Verify(channel => channel.Acknowledge(It.IsAny<ulong>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never, "BasicAck should not be called when DisableAck is true.");
+            mockservice.Verify(channel => channel.Acknowledge(It.IsAny<ulong>(), It.IsAny<bool>(), It.IsAny<string>()), Times.Never, "BasicAck should not be called when DisableAck is true.");
         }
         else
         {
-            mockservice.Verify(channel => channel.Acknowledge(It.IsAny<ulong>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Once, "BasicAck should be called when DisableAck is false.");
+            mockservice.Verify(channel => channel.Acknowledge(It.IsAny<ulong>(), It.IsAny<bool>(), It.IsAny<string>()), Times.Once, "BasicAck should be called when DisableAck is false.");
         }
     }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQTriggerBindingTests.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQTriggerBindingTests.cs
@@ -52,7 +52,7 @@ public class RabbitMQTriggerBindingTests
 
         ReadOnlyMemory<byte> body = buffer;
         var eventArgs = new BasicDeliverEventArgs("ConsumerName", deliveryTag, false, "n/a", "QueueName", null, body);
-        var messageActions = new RabbitMQMessageActions(Mock.Of<IModel>());
+        var messageActions = new RabbitMQMessageActions(Mock.Of<IRabbitMQService>());
 
         var data = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
         {
@@ -93,7 +93,7 @@ public class RabbitMQTriggerBindingTests
 
         ReadOnlyMemory<byte> body = buffer;
         var eventArgs = new BasicDeliverEventArgs("ConsumerName", deliveryTag, false, "n/a", "QueueName", null, body);
-        var messageActions = new RabbitMQMessageActions(Mock.Of<IModel>());
+        var messageActions = new RabbitMQMessageActions(Mock.Of<IRabbitMQService>());
 
         IReadOnlyDictionary<string, object> bindingData = RabbitMQTriggerBinding.CreateBindingData(eventArgs, messageActions);
 
@@ -108,7 +108,10 @@ public class RabbitMQTriggerBindingTests
     public async Task RabbitMQTrigger_ManualAck_BasicAckBehavior(bool manualAck)
     {
         // Arrange
-        var mockChannel = new Mock<IModel>();
+        var mockservice = new Mock<IRabbitMQService>();
+        var mockModel = new Mock<IModel>();
+        mockservice.Setup(a => a.CreateConsumer()).Returns(new AsyncEventingBasicConsumer(mockModel.Object));
+
         var mockExecutor = new Mock<ITriggeredFunctionExecutor>();
         var mockLogger = new Mock<ILogger>();
         var mockDrainModeManager = new Mock<IDrainModeManager>();
@@ -120,7 +123,7 @@ public class RabbitMQTriggerBindingTests
             .ReturnsAsync(new FunctionResult(true));
 
         var listener = new RabbitMQListener(
-            mockChannel.Object,
+            mockservice.Object,
             mockExecutor.Object,
             mockLogger.Object,
             functionId: "test-function",
@@ -139,13 +142,13 @@ public class RabbitMQTriggerBindingTests
         // Act
         await listener.StartAsync(CancellationToken.None);
 
-        // Find the IBasicConsumer passed to BasicConsume
-        IInvocation basicConsumeInvocation = mockChannel.Invocations
-            .FirstOrDefault(invocation => invocation.Method.Name == "BasicConsume");
+        // Find the Consumer instance passed to RabbitMQService.Consume method
+        IInvocation basicConsumeInvocation = mockservice.Invocations
+            .FirstOrDefault(invocation => invocation.Method.Name == "Consume");
 
         Assert.NotNull(basicConsumeInvocation);
 
-        var consumer = basicConsumeInvocation.Arguments[6] as AsyncEventingBasicConsumer;
+        var consumer = basicConsumeInvocation.Arguments[2] as AsyncEventingBasicConsumer;
         Assert.NotNull(consumer);
 
         // Simulate message delivery
@@ -161,11 +164,11 @@ public class RabbitMQTriggerBindingTests
         // Assert
         if (manualAck)
         {
-            mockChannel.Verify(channel => channel.BasicAck(It.IsAny<ulong>(), It.IsAny<bool>()), Times.Never, "BasicAck should not be called when ManualAck is true.");
+            mockservice.Verify(channel => channel.Acknowledge(It.IsAny<ulong>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never, "BasicAck should not be called when ManualAck is true.");
         }
         else
         {
-            mockChannel.Verify(channel => channel.BasicAck(It.IsAny<ulong>(), It.IsAny<bool>()), Times.AtLeastOnce, "BasicAck should be called when ManualAck is false.");
+            mockservice.Verify(channel => channel.Acknowledge(It.IsAny<ulong>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Once, "BasicAck should be called when ManualAck is false.");
         }
     }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQTriggerBindingTests.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQTriggerBindingTests.cs
@@ -74,26 +74,6 @@ public class RabbitMQTriggerBindingTests
         }
     }
 
-    [Fact]
-    public void RabbitMQTriggerBinding_CreateBindingData_IncludesRabbitMQMessageActions()
-    {
-        ulong deliveryTag = 1;
-
-        var rand = new Random();
-        byte[] buffer = new byte[10];
-        rand.NextBytes(buffer);
-
-        ReadOnlyMemory<byte> body = buffer;
-        var eventArgs = new BasicDeliverEventArgs("ConsumerName", deliveryTag, false, "n/a", "QueueName", null, body);
-        var messageActions = new RabbitMQMessageActions(Mock.Of<IRabbitMQService>());
-
-        IReadOnlyDictionary<string, object> bindingData = RabbitMQTriggerBinding.CreateBindingData(eventArgs, messageActions);
-
-        // Assert
-        Assert.True(bindingData.ContainsKey("MessageActions"), "Binding data should include MessageActions.");
-        Assert.Equal(messageActions, bindingData["MessageActions"]);
-    }
-
     [Theory]
     [InlineData(true)]
     [InlineData(false)]

--- a/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQTriggerBindingTests.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQTriggerBindingTests.cs
@@ -24,7 +24,7 @@ public class RabbitMQTriggerBindingTests
             ["RoutingKey"] = typeof(string),
             ["BasicProperties"] = typeof(IBasicProperties),
             ["Body"] = typeof(ReadOnlyMemory<byte>),
-            ["RabbitMQMessageActions"] = typeof(RabbitMQMessageActions),
+            ["MessageActions"] = typeof(RabbitMQMessageActions),
         };
 
         IReadOnlyDictionary<string, Type> actualContract = RabbitMQTriggerBinding.CreateBindingDataContract();
@@ -57,7 +57,7 @@ public class RabbitMQTriggerBindingTests
             ["Body"] = body,
             ["Exchange"] = eventArgs.Exchange,
             ["BasicProperties"] = eventArgs.BasicProperties,
-            ["RabbitMQMessageActions"] = messageActions,
+            ["MessageActions"] = messageActions,
         };
 
         IReadOnlyDictionary<string, object> actualContract = RabbitMQTriggerBinding.CreateBindingData(eventArgs, messageActions);
@@ -92,7 +92,7 @@ public class RabbitMQTriggerBindingTests
         IReadOnlyDictionary<string, object> bindingData = RabbitMQTriggerBinding.CreateBindingData(eventArgs, messageActions);
 
         // Assert
-        Assert.True(bindingData.ContainsKey("RabbitMQMessageActions"), "Binding data should include RabbitMQMessageActions.");
-        Assert.Equal(messageActions, bindingData["RabbitMQMessageActions"]);
+        Assert.True(bindingData.ContainsKey("MessageActions"), "Binding data should include MessageActions.");
+        Assert.Equal(messageActions, bindingData["MessageActions"]);
     }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQTriggerBindingTests.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.Tests/RabbitMQTriggerBindingTests.cs
@@ -75,14 +75,6 @@ public class RabbitMQTriggerBindingTests
     }
 
     [Fact]
-    public void RabbitMQTriggerAttribute_ManualAck_DefaultsToFalse()
-    {
-        var attribute = new RabbitMQTriggerAttribute("test-queue");
-        bool manualAck = attribute.ManualAck;
-        Assert.False(manualAck, "ManualAck should default to false.");
-    }
-
-    [Fact]
     public void RabbitMQTriggerBinding_CreateBindingData_IncludesRabbitMQMessageActions()
     {
         ulong deliveryTag = 1;
@@ -105,7 +97,7 @@ public class RabbitMQTriggerBindingTests
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task RabbitMQTrigger_ManualAck_BasicAckBehavior(bool manualAck)
+    public async Task RabbitMQTrigger_ManualAck_BasicAckBehavior(bool disableAck)
     {
         // Arrange
         var mockservice = new Mock<IRabbitMQService>();
@@ -128,7 +120,7 @@ public class RabbitMQTriggerBindingTests
             mockLogger.Object,
             functionId: "test-function",
             queueName: "test-queue",
-            manualAck: manualAck,
+            disableAck: disableAck,
             prefetchCount: 10,
             drainModeManager: mockDrainModeManager.Object);
 
@@ -162,13 +154,13 @@ public class RabbitMQTriggerBindingTests
             body: eventArgs.Body.ToArray());
 
         // Assert
-        if (manualAck)
+        if (disableAck)
         {
-            mockservice.Verify(channel => channel.Acknowledge(It.IsAny<ulong>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never, "BasicAck should not be called when ManualAck is true.");
+            mockservice.Verify(channel => channel.Acknowledge(It.IsAny<ulong>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never, "BasicAck should not be called when DisableAck is true.");
         }
         else
         {
-            mockservice.Verify(channel => channel.Acknowledge(It.IsAny<ulong>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Once, "BasicAck should be called when ManualAck is false.");
+            mockservice.Verify(channel => channel.Acknowledge(It.IsAny<ulong>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Once, "BasicAck should be called when DisableAck is false.");
         }
     }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ.Tests/Trigger/RabbitMQListenerTests.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.Tests/Trigger/RabbitMQListenerTests.cs
@@ -205,7 +205,7 @@ public class RabbitMQListenerTests
     private static RabbitMQListener GetScaleMonitor(string functionId, string queueName)
     {
         return new RabbitMQListener(
-            Mock.Of<IModel>(),
+            Mock.Of<IRabbitMQService>(),
             Mock.Of<ITriggeredFunctionExecutor>(),
             Mock.Of<ILogger>(),
             functionId,
@@ -220,7 +220,7 @@ public class RabbitMQListenerTests
         (Mock<ILogger> mockLogger, List<string> logMessages) = CreateMockLogger();
 
         IScaleMonitor<RabbitMQTriggerMetrics> monitor = new RabbitMQListener(
-            Mock.Of<IModel>(),
+            Mock.Of<IRabbitMQService>(),
             Mock.Of<ITriggeredFunctionExecutor>(),
             mockLogger.Object,
             "testFunctionId",

--- a/extension/WebJobs.Extensions.RabbitMQ.Tests/Trigger/RabbitMQListenerTests.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.Tests/Trigger/RabbitMQListenerTests.cs
@@ -210,6 +210,7 @@ public class RabbitMQListenerTests
             Mock.Of<ILogger>(),
             functionId,
             queueName,
+            false,
             7357,
             DrainModeManager);
     }
@@ -224,6 +225,7 @@ public class RabbitMQListenerTests
             mockLogger.Object,
             "testFunctionId",
             "testQueueName",
+            false,
             7357,
             DrainModeManager);
 

--- a/extension/WebJobs.Extensions.RabbitMQ/Bindings/RabbitMQClientBuilder.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Bindings/RabbitMQClientBuilder.cs
@@ -7,17 +7,17 @@ using RabbitMQ.Client;
 
 namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ;
 
-internal class RabbitMQClientBuilder(RabbitMQExtensionConfigProvider configProvider, IOptions<RabbitMQOptions> options) : IConverter<RabbitMQAttribute, IModel>
+internal class RabbitMQClientBuilder(RabbitMQExtensionConfigProvider configProvider, IOptions<RabbitMQOptions> options) : IConverter<RabbitMQAttribute, IRabbitMQService>
 {
     private readonly RabbitMQExtensionConfigProvider configProvider = configProvider;
     private readonly IOptions<RabbitMQOptions> options = options;
 
-    public IModel Convert(RabbitMQAttribute attribute)
+    public IRabbitMQService Convert(RabbitMQAttribute attribute)
     {
         return this.CreateModelFromAttribute(attribute);
     }
 
-    private IModel CreateModelFromAttribute(RabbitMQAttribute attribute)
+    private IRabbitMQService CreateModelFromAttribute(RabbitMQAttribute attribute)
     {
         if (attribute == null)
         {
@@ -27,8 +27,6 @@ internal class RabbitMQClientBuilder(RabbitMQExtensionConfigProvider configProvi
         string resolvedConnectionString = Utility.FirstOrDefault(attribute.ConnectionStringSetting, this.options.Value.ConnectionString);
         bool resolvedDisableCertificateValidation = Utility.FirstOrDefault(attribute.DisableCertificateValidation, this.options.Value.DisableCertificateValidation);
 
-        IRabbitMQService service = this.configProvider.GetService(resolvedConnectionString, resolvedDisableCertificateValidation);
-
-        return service.Model;
+        return this.configProvider.GetService(resolvedConnectionString, resolvedDisableCertificateValidation);
     }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ/Config/DefaultRabbitMQServiceFactory.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Config/DefaultRabbitMQServiceFactory.cs
@@ -1,17 +1,19 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using Microsoft.Extensions.Logging;
+
 namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ;
 
 internal class DefaultRabbitMQServiceFactory : IRabbitMQServiceFactory
 {
-    public IRabbitMQService CreateService(string connectionString, string queueName, bool disableCertificateValidation)
+    public IRabbitMQService CreateService(string connectionString, string queueName, bool disableCertificateValidation, ILogger logger)
     {
-        return new RabbitMQService(connectionString, queueName, disableCertificateValidation);
+        return new RabbitMQService(connectionString, queueName, disableCertificateValidation, logger);
     }
 
-    public IRabbitMQService CreateService(string connectionString, bool disableCertificateValidation)
+    public IRabbitMQService CreateService(string connectionString, bool disableCertificateValidation, ILogger logger)
     {
-        return new RabbitMQService(connectionString, disableCertificateValidation);
+        return new RabbitMQService(connectionString, disableCertificateValidation, logger);
     }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ/Config/IRabbitMQServiceFactory.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Config/IRabbitMQServiceFactory.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using Microsoft.Extensions.Logging;
+
 namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ;
 
 public interface IRabbitMQServiceFactory
 {
-    IRabbitMQService CreateService(string connectionString, string queueName, bool disableCertificateValidation);
+    IRabbitMQService CreateService(string connectionString, string queueName, bool disableCertificateValidation, ILogger logger);
 
-    IRabbitMQService CreateService(string connectionString, bool disableCertificateValidation);
+    IRabbitMQService CreateService(string connectionString, bool disableCertificateValidation, ILogger logger);
 }

--- a/extension/WebJobs.Extensions.RabbitMQ/Config/RabbitMQExtensionConfigProvider.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Config/RabbitMQExtensionConfigProvider.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -84,7 +84,7 @@ internal class RabbitMQExtensionConfigProvider(IOptions<RabbitMQOptions> options
         string[] keyArray =
             [connectionString, queueName, disableCertificateValidation.ToString()];
         string key = string.Join(",", keyArray);
-        return this.connectionParametersToService.GetOrAdd(key, _ => this.rabbitMQServiceFactory.CreateService(connectionString, queueName, disableCertificateValidation));
+        return this.connectionParametersToService.GetOrAdd(key, _ => this.rabbitMQServiceFactory.CreateService(connectionString, queueName, disableCertificateValidation, this.logger));
     }
 
     // Overloaded method used only for getting the RabbitMQ client.
@@ -93,6 +93,6 @@ internal class RabbitMQExtensionConfigProvider(IOptions<RabbitMQOptions> options
         string[] keyArray =
             [connectionString, disableCertificateValidation.ToString()];
         string key = string.Join(",", keyArray);
-        return this.connectionParametersToService.GetOrAdd(key, _ => this.rabbitMQServiceFactory.CreateService(connectionString, disableCertificateValidation));
+        return this.connectionParametersToService.GetOrAdd(key, _ => this.rabbitMQServiceFactory.CreateService(connectionString, disableCertificateValidation, this.logger));
     }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ/Services/IRabbitMQService.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Services/IRabbitMQService.cs
@@ -25,11 +25,9 @@ public interface IRabbitMQService
 
     void OnMessageConsumed(string consumerTag, ulong deliveryTag);
 
-    void Acknowledge(ulong deliveryTag, bool multiple, string logDetails, bool throwOnMissing = false);
+    void Acknowledge(ulong deliveryTag, bool multiple, string logDetails);
 
-    void Reject(ulong deliveryTag, bool requeue, string logDetails, bool throwOnMissing = false);
-
-    BasicGetResult Get(string queue, bool autoAck);
+    void Reject(ulong deliveryTag, bool requeue, string logDetails);
 
     void Publish(string exchange, string routingKey, IBasicProperties basicProperties, ReadOnlyMemory<byte> body);
 

--- a/extension/WebJobs.Extensions.RabbitMQ/Services/IRabbitMQService.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Services/IRabbitMQService.cs
@@ -1,17 +1,39 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
 
 namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ;
 
 public interface IRabbitMQService
 {
-    IModel Model { get; }
-
     IBasicPublishBatch BasicPublishBatch { get; }
 
     object PublishBatchLock { get; }
 
     void ResetPublishBatch();
+
+    void ConfigureQos(uint prefetchSize, ushort prefetchCount, bool global);
+
+    QueueDeclareOk GetQueueInfo(string queueName);
+
+    AsyncEventingBasicConsumer CreateConsumer();
+
+    string Consume(string queue, bool autoAck, AsyncEventingBasicConsumer consumer);
+
+    void OnMessageConsumed(string consumerTag, ulong deliveryTag);
+
+    void Acknowledge(ulong deliveryTag, bool multiple, string logDetails, bool throwOnMissing = false);
+
+    void Reject(ulong deliveryTag, bool requeue, string logDetails, bool throwOnMissing = false);
+
+    BasicGetResult Get(string queue, bool autoAck);
+
+    void Publish(string exchange, string routingKey, IBasicProperties basicProperties, ReadOnlyMemory<byte> body);
+
+    void Cancel(string consumerTag);
+
+    void Close();
 }

--- a/extension/WebJobs.Extensions.RabbitMQ/Services/RabbitMQService.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Services/RabbitMQService.cs
@@ -2,15 +2,19 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Net.Security;
 using Microsoft.Extensions.Logging;
 using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
 
 namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ;
 
 internal sealed class RabbitMQService : IRabbitMQService
 {
     private readonly ILogger logger;
+    private readonly IModel model;
+    private readonly ConcurrentDictionary<ulong, byte> deliveredTags = new();
 
     public RabbitMQService(string connectionString, bool disableCertificateValidation, ILogger logger)
     {
@@ -28,7 +32,7 @@ internal sealed class RabbitMQService : IRabbitMQService
         }
 
         this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        this.Model = this.AddShutdownHandler(connectionFactory.CreateConnection().CreateModel());
+        this.model = this.AddShutdownHandler(connectionFactory.CreateConnection().CreateModel());
         this.PublishBatchLock = new object();
     }
 
@@ -37,11 +41,9 @@ internal sealed class RabbitMQService : IRabbitMQService
     {
         _ = queueName ?? throw new ArgumentNullException(nameof(queueName));
 
-        this.Model.QueueDeclarePassive(queueName); // Throws exception if queue doesn't exist
-        this.BasicPublishBatch = this.Model.CreateBasicPublishBatch();
+        this.model.QueueDeclarePassive(queueName); // Throws exception if queue doesn't exist
+        this.BasicPublishBatch = this.model.CreateBasicPublishBatch();
     }
-
-    public IModel Model { get; }
 
     public IBasicPublishBatch BasicPublishBatch { get; private set; }
 
@@ -50,7 +52,92 @@ internal sealed class RabbitMQService : IRabbitMQService
     // Typically called after a flush
     public void ResetPublishBatch()
     {
-        this.BasicPublishBatch = this.Model.CreateBasicPublishBatch();
+        this.BasicPublishBatch = this.model.CreateBasicPublishBatch();
+    }
+
+    public void ConfigureQos(uint prefetchSize, ushort prefetchCount, bool global)
+    {
+        this.model.BasicQos(prefetchSize, prefetchCount, global);
+    }
+
+    public QueueDeclareOk GetQueueInfo(string queueName)
+    {
+        return this.model.QueueDeclarePassive(queueName);
+    }
+
+    public AsyncEventingBasicConsumer CreateConsumer()
+    {
+        return new AsyncEventingBasicConsumer(this.model);
+    }
+
+    public string Consume(string queue, bool autoAck, AsyncEventingBasicConsumer consumer)
+    {
+        return this.model.BasicConsume(queue, autoAck, consumer);
+    }
+
+    public void OnMessageConsumed(string consumerTag, ulong deliveryTag)
+    {
+        this.deliveredTags.TryAdd(deliveryTag, 0);
+    }
+
+    public void Acknowledge(ulong deliveryTag, bool multiple, string logDetails, bool throwOnMissing = false)
+    {
+        if (this.deliveredTags.TryRemove(deliveryTag, out _))
+        {
+            this.model.BasicAck(deliveryTag, multiple);
+        }
+        else
+        {
+            string message = $"Failed to acknowledge the message. deliveryTag ({deliveryTag}) not found.";
+            if (throwOnMissing)
+            {
+                throw new InvalidOperationException(message);
+            }
+            else
+            {
+                this.logger.LogError($"{message} for {logDetails}");
+            }
+        }
+    }
+
+    public void Reject(ulong deliveryTag, bool requeue, string logDetails, bool throwOnMissing = false)
+    {
+        if (this.deliveredTags.TryRemove(deliveryTag, out _))
+        {
+            this.model.BasicReject(deliveryTag, requeue);
+        }
+        else
+        {
+            string message = $"Failed to acknowledge the message. deliveryTag ({deliveryTag}) not found.";
+            if (throwOnMissing)
+            {
+                throw new InvalidOperationException(message);
+            }
+            else
+            {
+                this.logger.LogError(message);
+            }
+        }
+    }
+
+    public BasicGetResult Get(string queue, bool autoAck)
+    {
+        return this.model.BasicGet(queue, autoAck);
+    }
+
+    public void Publish(string exchange, string routingKey, IBasicProperties basicProperties, ReadOnlyMemory<byte> body)
+    {
+        this.model.BasicPublish(exchange, routingKey, mandatory: false, basicProperties, body);
+    }
+
+    public void Cancel(string consumerTag)
+    {
+        this.model.BasicCancel(consumerTag);
+    }
+
+    public void Close()
+    {
+        this.model.Close();
     }
 
     private IModel AddShutdownHandler(IModel model)

--- a/extension/WebJobs.Extensions.RabbitMQ/Services/RabbitMQService.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Services/RabbitMQService.cs
@@ -80,7 +80,7 @@ internal sealed class RabbitMQService : IRabbitMQService
         this.deliveredTags.TryAdd(deliveryTag, 0);
     }
 
-    public void Acknowledge(ulong deliveryTag, bool multiple, string logDetails, bool throwOnMissing = false)
+    public void Acknowledge(ulong deliveryTag, bool multiple, string logDetails)
     {
         if (this.deliveredTags.TryRemove(deliveryTag, out _))
         {
@@ -88,19 +88,11 @@ internal sealed class RabbitMQService : IRabbitMQService
         }
         else
         {
-            string message = $"Failed to acknowledge the message. deliveryTag ({deliveryTag}) not found.";
-            if (throwOnMissing)
-            {
-                throw new InvalidOperationException(message);
-            }
-            else
-            {
-                this.logger.LogError($"{message} for {logDetails}");
-            }
+            this.logger.LogError($"Failed to acknowledge the message. DeliveryTag ({deliveryTag}) not found for {logDetails}");
         }
     }
 
-    public void Reject(ulong deliveryTag, bool requeue, string logDetails, bool throwOnMissing = false)
+    public void Reject(ulong deliveryTag, bool requeue, string logDetails)
     {
         if (this.deliveredTags.TryRemove(deliveryTag, out _))
         {
@@ -108,21 +100,8 @@ internal sealed class RabbitMQService : IRabbitMQService
         }
         else
         {
-            string message = $"Failed to acknowledge the message. deliveryTag ({deliveryTag}) not found.";
-            if (throwOnMissing)
-            {
-                throw new InvalidOperationException(message);
-            }
-            else
-            {
-                this.logger.LogError(message);
-            }
+            this.logger.LogError($"Failed to reject the message. DeliveryTag ({deliveryTag}) not found for {logDetails}");
         }
-    }
-
-    public BasicGetResult Get(string queue, bool autoAck)
-    {
-        return this.model.BasicGet(queue, autoAck);
     }
 
     public void Publish(string exchange, string routingKey, IBasicProperties basicProperties, ReadOnlyMemory<byte> body)

--- a/extension/WebJobs.Extensions.RabbitMQ/Services/RabbitMQService.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Services/RabbitMQService.cs
@@ -3,13 +3,16 @@
 
 using System;
 using System.Net.Security;
+using Microsoft.Extensions.Logging;
 using RabbitMQ.Client;
 
 namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ;
 
 internal sealed class RabbitMQService : IRabbitMQService
 {
-    public RabbitMQService(string connectionString, bool disableCertificateValidation)
+    private readonly ILogger logger;
+
+    public RabbitMQService(string connectionString, bool disableCertificateValidation, ILogger logger)
     {
         var connectionFactory = new ConnectionFactory
         {
@@ -24,12 +27,13 @@ internal sealed class RabbitMQService : IRabbitMQService
             connectionFactory.Ssl.AcceptablePolicyErrors |= SslPolicyErrors.RemoteCertificateChainErrors;
         }
 
-        this.Model = connectionFactory.CreateConnection().CreateModel();
+        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        this.Model = this.AddShutdownHandler(connectionFactory.CreateConnection().CreateModel());
         this.PublishBatchLock = new object();
     }
 
-    public RabbitMQService(string connectionString, string queueName, bool disableCertificateValidation)
-        : this(connectionString, disableCertificateValidation)
+    public RabbitMQService(string connectionString, string queueName, bool disableCertificateValidation, ILogger logger)
+        : this(connectionString, disableCertificateValidation, logger)
     {
         _ = queueName ?? throw new ArgumentNullException(nameof(queueName));
 
@@ -47,5 +51,14 @@ internal sealed class RabbitMQService : IRabbitMQService
     public void ResetPublishBatch()
     {
         this.BasicPublishBatch = this.Model.CreateBasicPublishBatch();
+    }
+
+    private IModel AddShutdownHandler(IModel model)
+    {
+        model.ModelShutdown += (sender, args) =>
+        {
+            this.logger.LogError($"[!] Channel closed due to error: {args.Exception?.Message}");
+        };
+        return model;
     }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQListener.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQListener.cs
@@ -149,7 +149,6 @@ internal sealed class RabbitMQListener : IListener, IScaleMonitor<RabbitMQTrigge
             else if (!this.manualAck)
             {
                 // Acknowledge the existing message if manualAck is not set and function execution was successful.
-                this.logger.LogDebug($"Acknowledging message for {this.logDetails} since manualAck is not set.");
                 this.channel.BasicAck(args.DeliveryTag, multiple: false);
             }
             else

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQListener.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQListener.cs
@@ -65,6 +65,12 @@ internal sealed class RabbitMQListener : IListener, IScaleMonitor<RabbitMQTrigge
         // Do not convert the scale-monitor ID to lower-case string since RabbitMQ queue names are case-sensitive.
         this.Descriptor = new ScaleMonitorDescriptor($"{functionId}-RabbitMQTrigger-{queueName}", functionId);
         this.logDetails = $"function: '{functionId}', queue: '{queueName}'";
+
+        // Add a handler to log any errors that occur on the channel.
+        channel.ModelShutdown += (sender, args) =>
+        {
+            logger.LogError($"[!] Channel closed due to error: {args.Exception?.Message}");
+        };
     }
 
     public ScaleMonitorDescriptor Descriptor { get; }

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQListener.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQListener.cs
@@ -65,12 +65,6 @@ internal sealed class RabbitMQListener : IListener, IScaleMonitor<RabbitMQTrigge
         // Do not convert the scale-monitor ID to lower-case string since RabbitMQ queue names are case-sensitive.
         this.Descriptor = new ScaleMonitorDescriptor($"{functionId}-RabbitMQTrigger-{queueName}", functionId);
         this.logDetails = $"function: '{functionId}', queue: '{queueName}'";
-
-        // Add a handler to log any errors that occur on the channel.
-        channel.ModelShutdown += (sender, args) =>
-        {
-            logger.LogError($"[!] Channel closed due to error: {args.Exception?.Message}");
-        };
     }
 
     public ScaleMonitorDescriptor Descriptor { get; }

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQListener.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQListener.cs
@@ -33,7 +33,7 @@ internal sealed class RabbitMQListener : IListener, IScaleMonitor<RabbitMQTrigge
     private readonly ILogger logger;
     private readonly string queueName;
     private readonly ushort prefetchCount;
-    private readonly bool manualAck;
+    private readonly bool disableAck;
     private readonly string logDetails;
     private readonly IDrainModeManager drainModeManager;
 
@@ -47,7 +47,7 @@ internal sealed class RabbitMQListener : IListener, IScaleMonitor<RabbitMQTrigge
         ILogger logger,
         string functionId,
         string queueName,
-        bool manualAck,
+        bool disableAck,
         ushort prefetchCount,
         IDrainModeManager drainModeManager)
     {
@@ -55,7 +55,7 @@ internal sealed class RabbitMQListener : IListener, IScaleMonitor<RabbitMQTrigge
         this.executor = executor ?? throw new ArgumentNullException(nameof(executor));
         this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
         this.queueName = !string.IsNullOrWhiteSpace(queueName) ? queueName : throw new ArgumentNullException(nameof(queueName));
-        this.manualAck = manualAck;
+        this.disableAck = disableAck;
         this.prefetchCount = prefetchCount;
         this.drainModeManager = drainModeManager;
         this.listenerCancellationTokenSource = new CancellationTokenSource();
@@ -144,7 +144,7 @@ internal sealed class RabbitMQListener : IListener, IScaleMonitor<RabbitMQTrigge
                 // Acknowledge the existing message after the message is re-published.
                 this.service.Acknowledge(args.DeliveryTag, multiple: false, logDetails: this.logDetails);
             }
-            else if (!this.manualAck)
+            else if (!this.disableAck)
             {
                 // Acknowledge the existing message if manualAck is not set and function execution was successful.
                 this.service.Acknowledge(args.DeliveryTag, multiple: false, logDetails: this.logDetails);

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQListener.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQListener.cs
@@ -28,7 +28,7 @@ internal sealed class RabbitMQListener : IListener, IScaleMonitor<RabbitMQTrigge
 
     private const string RequeueCountHeaderName = "x-ms-rabbitmq-requeuecount";
 
-    private readonly IModel channel;
+    private readonly IRabbitMQService service;
     private readonly ITriggeredFunctionExecutor executor;
     private readonly ILogger logger;
     private readonly string queueName;
@@ -42,7 +42,7 @@ internal sealed class RabbitMQListener : IListener, IScaleMonitor<RabbitMQTrigge
     private string consumerTag;
 
     public RabbitMQListener(
-        IModel channel,
+        IRabbitMQService service,
         ITriggeredFunctionExecutor executor,
         ILogger logger,
         string functionId,
@@ -51,7 +51,7 @@ internal sealed class RabbitMQListener : IListener, IScaleMonitor<RabbitMQTrigge
         ushort prefetchCount,
         IDrainModeManager drainModeManager)
     {
-        this.channel = channel ?? throw new ArgumentNullException(nameof(channel));
+        this.service = service ?? throw new ArgumentNullException(nameof(service));
         this.executor = executor ?? throw new ArgumentNullException(nameof(executor));
         this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
         this.queueName = !string.IsNullOrWhiteSpace(queueName) ? queueName : throw new ArgumentNullException(nameof(queueName));
@@ -93,14 +93,16 @@ internal sealed class RabbitMQListener : IListener, IScaleMonitor<RabbitMQTrigge
         // The RabbitMQ server (v3.11.2 as of latest) only has support for prefetch size of zero (no specific limit).
         // See: https://github.com/rabbitmq/rabbitmq-server/blob/v3.11.2/deps/rabbit/src/rabbit_channel.erl#L1543.
         // See: https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.qos.prefetch-size for protocol specification.
-        this.channel.BasicQos(prefetchSize: 0, this.prefetchCount, global: false);
+        this.service.ConfigureQos(prefetchSize: 0, this.prefetchCount, global: false);
 
         // We should use AsyncEventingBasicConsumer to create the consumer since our handler method is async. Using
         // EventingBasicConsumer led to issue: https://github.com/Azure/azure-functions-rabbitmq-extension/issues/211).
-        var consumer = new AsyncEventingBasicConsumer(this.channel);
+        AsyncEventingBasicConsumer consumer = this.service.CreateConsumer();
+
         consumer.Received += ReceivedHandler;
 
-        this.consumerTag = this.channel.BasicConsume(this.queueName, autoAck: false, consumer);
+        this.consumerTag = this.service.Consume(this.queueName, autoAck: false, consumer);
+        this.logger.LogDebug($"Started consuming with consumerTag: {this.consumerTag} for {this.logDetails}.");
 
         this.listenerState = ListenerStarted;
         this.logger.LogDebug($"Started RabbitMQ trigger listener for {this.logDetails}.");
@@ -109,6 +111,8 @@ internal sealed class RabbitMQListener : IListener, IScaleMonitor<RabbitMQTrigge
 
         async Task ReceivedHandler(object model, BasicDeliverEventArgs args)
         {
+            this.service.OnMessageConsumed(args.ConsumerTag, args.DeliveryTag);
+
             using Activity activity = RabbitMQActivitySource.StartActivity(args.BasicProperties);
 
             var input = new TriggeredFunctionData() { TriggerValue = args };
@@ -126,7 +130,7 @@ internal sealed class RabbitMQListener : IListener, IScaleMonitor<RabbitMQTrigge
                 {
                     // Discard or 'dead-letter' the message. See: https://www.rabbitmq.com/dlx.html.
                     this.logger.LogDebug($"Rejecting message since the requeue count exceeded for {this.logDetails}.");
-                    this.channel.BasicReject(args.DeliveryTag, requeue: false);
+                    this.service.Reject(args.DeliveryTag, requeue: false, logDetails: this.logDetails);
                     return;
                 }
 
@@ -135,15 +139,15 @@ internal sealed class RabbitMQListener : IListener, IScaleMonitor<RabbitMQTrigge
 
                 // We cannot call BasicReject() on the message with requeue = true since that would not enable a fixed
                 // number of retry attempts. See: https://stackoverflow.com/q/23158310.
-                this.channel.BasicPublish(exchange: string.Empty, routingKey: this.queueName, args.BasicProperties, args.Body);
+                this.service.Publish(exchange: string.Empty, routingKey: this.queueName, args.BasicProperties, args.Body);
 
                 // Acknowledge the existing message after the message is re-published.
-                this.channel.BasicAck(args.DeliveryTag, multiple: false);
+                this.service.Acknowledge(args.DeliveryTag, multiple: false, logDetails: this.logDetails);
             }
             else if (!this.manualAck)
             {
                 // Acknowledge the existing message if manualAck is not set and function execution was successful.
-                this.channel.BasicAck(args.DeliveryTag, multiple: false);
+                this.service.Acknowledge(args.DeliveryTag, multiple: false, logDetails: this.logDetails);
             }
             else
             {
@@ -160,8 +164,8 @@ internal sealed class RabbitMQListener : IListener, IScaleMonitor<RabbitMQTrigge
         if (previousState == ListenerStarted)
         {
             // TODO: Close RabbitMQ connection along with the channel.
-            this.channel.BasicCancel(this.consumerTag);
-            this.channel.Close();
+            this.service.Cancel(this.consumerTag);
+            this.service.Close();
 
             if (!this.drainModeManager.IsDrainModeEnabled)
             {
@@ -182,7 +186,7 @@ internal sealed class RabbitMQListener : IListener, IScaleMonitor<RabbitMQTrigge
 
     public Task<RabbitMQTriggerMetrics> GetMetricsAsync()
     {
-        QueueDeclareOk queueInfo = this.channel.QueueDeclarePassive(this.queueName);
+        QueueDeclareOk queueInfo = this.service.GetQueueInfo(this.queueName);
 
         var metrics = new RabbitMQTriggerMetrics
         {

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQListener.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQListener.cs
@@ -149,7 +149,13 @@ internal sealed class RabbitMQListener : IListener, IScaleMonitor<RabbitMQTrigge
             else if (!this.manualAck)
             {
                 // Acknowledge the existing message if manualAck is not set and function execution was successful.
+                this.logger.LogDebug($"Acknowledging message for {this.logDetails} since manualAck is not set.");
                 this.channel.BasicAck(args.DeliveryTag, multiple: false);
+            }
+            else
+            {
+                // Do not acknowledge the message if manualAck is set and function execution was successful.
+                this.logger.LogDebug($"Not acknowledging message for {this.logDetails} since manualAck is set.");
             }
         }
     }

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQListener.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQListener.cs
@@ -33,6 +33,7 @@ internal sealed class RabbitMQListener : IListener, IScaleMonitor<RabbitMQTrigge
     private readonly ILogger logger;
     private readonly string queueName;
     private readonly ushort prefetchCount;
+    private readonly bool manualAck;
     private readonly string logDetails;
     private readonly IDrainModeManager drainModeManager;
 
@@ -46,6 +47,7 @@ internal sealed class RabbitMQListener : IListener, IScaleMonitor<RabbitMQTrigge
         ILogger logger,
         string functionId,
         string queueName,
+        bool manualAck,
         ushort prefetchCount,
         IDrainModeManager drainModeManager)
     {
@@ -53,6 +55,7 @@ internal sealed class RabbitMQListener : IListener, IScaleMonitor<RabbitMQTrigge
         this.executor = executor ?? throw new ArgumentNullException(nameof(executor));
         this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
         this.queueName = !string.IsNullOrWhiteSpace(queueName) ? queueName : throw new ArgumentNullException(nameof(queueName));
+        this.manualAck = manualAck;
         this.prefetchCount = prefetchCount;
         this.drainModeManager = drainModeManager;
         this.listenerCancellationTokenSource = new CancellationTokenSource();
@@ -133,10 +136,15 @@ internal sealed class RabbitMQListener : IListener, IScaleMonitor<RabbitMQTrigge
                 // We cannot call BasicReject() on the message with requeue = true since that would not enable a fixed
                 // number of retry attempts. See: https://stackoverflow.com/q/23158310.
                 this.channel.BasicPublish(exchange: string.Empty, routingKey: this.queueName, args.BasicProperties, args.Body);
-            }
 
-            // Acknowledge the existing message only after the message (in case of failure) is re-published.
-            this.channel.BasicAck(args.DeliveryTag, multiple: false);
+                // Acknowledge the existing message after the message is re-published.
+                this.channel.BasicAck(args.DeliveryTag, multiple: false);
+            }
+            else if (!this.manualAck)
+            {
+                // Acknowledge the existing message if manualAck is not set and function execution was successful.
+                this.channel.BasicAck(args.DeliveryTag, multiple: false);
+            }
         }
     }
 

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQMessageActions.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQMessageActions.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Threading;
-using Microsoft.Azure.WebJobs.Host.Scale;
+using System.Threading.Tasks;
 using RabbitMQ.Client;
 
 namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ;
@@ -18,23 +16,35 @@ public class RabbitMQMessageActions
         this.service = service;
     }
 
-    public void BasicReject(ulong deliveryTag, bool requeue = false)
+    public async Task BasicReject(ulong deliveryTag, bool requeue = false)
     {
-        this.service.Reject(deliveryTag, requeue, logDetails: string.Empty, throwOnMissing: true);
+        await Task.Run(() =>
+        {
+            this.service.Reject(deliveryTag, requeue, logDetails: string.Empty, throwOnMissing: true);
+        });
     }
 
-    public void BasicAck(ulong deliveryTag, bool multiple = false)
+    public async Task BasicAck(ulong deliveryTag, bool multiple = false)
     {
-        this.service.Acknowledge(deliveryTag, multiple, logDetails: string.Empty, throwOnMissing: true);
+        await Task.Run(() =>
+        {
+            this.service.Acknowledge(deliveryTag, multiple, logDetails: string.Empty, throwOnMissing: true);
+        });
     }
 
-    public void BasicPublish(string exchange, string routingKey, IBasicProperties basicProperties, ReadOnlyMemory<byte> body)
+    public async Task BasicPublish(string exchange, string routingKey, IBasicProperties basicProperties, ReadOnlyMemory<byte> body)
     {
-        this.service.Publish(exchange, routingKey, basicProperties, body);
+        await Task.Run(() =>
+        {
+            this.service.Publish(exchange, routingKey, basicProperties, body);
+        });
     }
 
-    public BasicGetResult BasicGet(string queue, bool autoAck)
+    public async Task<BasicGetResult> BasicGet(string queue, bool autoAck)
     {
-        return this.service.Get(queue, autoAck);
+        return await Task.Run(() =>
+        {
+            return this.service.Get(queue, autoAck);
+        });
     }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQMessageActions.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQMessageActions.cs
@@ -23,15 +23,15 @@ public class RabbitMQMessageActions
     {
         await Task.Run(() =>
         {
-            this.service.Reject(this.message.DeliveryTag, requeue, logDetails: $"ConsumerTag: {this.message.ConsumerTag}");
+            this.service.Reject(deliveryTag: this.message.DeliveryTag, requeue, logDetails: $"ConsumerTag: {this.message.ConsumerTag}");
         });
     }
 
-    public async Task Acknowledge(bool multiple = false)
+    public async Task Acknowledge()
     {
         await Task.Run(() =>
         {
-            this.service.Acknowledge(this.message.DeliveryTag, multiple, logDetails: $"ConsumerTag: {this.message.ConsumerTag}");
+            this.service.Acknowledge(deliveryTag: this.message.DeliveryTag, multiple: false, logDetails: $"ConsumerTag: {this.message.ConsumerTag}");
         });
     }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQMessageActions.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQMessageActions.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.Azure.WebJobs.Host.Scale;
+using RabbitMQ.Client;
+
+namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ;
+
+public class RabbitMQMessageActions
+{
+    private readonly IModel channel;
+
+    internal RabbitMQMessageActions(IModel channel)
+    {
+        this.channel = channel;
+    }
+
+    public void BasicReject(ulong deliveryTag)
+    {
+        this.channel.BasicReject(deliveryTag, requeue: false);
+    }
+
+    public void BasicAck(ulong deliveryTag)
+    {
+        this.channel.BasicAck(deliveryTag, multiple: false);
+    }
+}

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQMessageActions.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQMessageActions.cs
@@ -17,13 +17,13 @@ public class RabbitMQMessageActions
         this.channel = channel;
     }
 
-    public void BasicReject(ulong deliveryTag)
+    public void BasicReject(ulong deliveryTag, bool requeue = false)
     {
-        this.channel.BasicReject(deliveryTag, requeue: false);
+        this.channel.BasicReject(deliveryTag, requeue: requeue);
     }
 
-    public void BasicAck(ulong deliveryTag)
+    public void BasicAck(ulong deliveryTag, bool multiple = false)
     {
-        this.channel.BasicAck(deliveryTag, multiple: false);
+        this.channel.BasicAck(deliveryTag, multiple: multiple);
     }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQMessageActions.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQMessageActions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using Microsoft.Azure.WebJobs.Host.Scale;
@@ -10,20 +11,30 @@ namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ;
 
 public class RabbitMQMessageActions
 {
-    private readonly IModel channel;
+    private readonly IRabbitMQService service;
 
-    internal RabbitMQMessageActions(IModel channel)
+    internal RabbitMQMessageActions(IRabbitMQService service)
     {
-        this.channel = channel;
+        this.service = service;
     }
 
     public void BasicReject(ulong deliveryTag, bool requeue = false)
     {
-        this.channel.BasicReject(deliveryTag, requeue: requeue);
+        this.service.Reject(deliveryTag, requeue, logDetails: string.Empty, throwOnMissing: true);
     }
 
     public void BasicAck(ulong deliveryTag, bool multiple = false)
     {
-        this.channel.BasicAck(deliveryTag, multiple: multiple);
+        this.service.Acknowledge(deliveryTag, multiple, logDetails: string.Empty, throwOnMissing: true);
+    }
+
+    public void BasicPublish(string exchange, string routingKey, IBasicProperties basicProperties, ReadOnlyMemory<byte> body)
+    {
+        this.service.Publish(exchange, routingKey, basicProperties, body);
+    }
+
+    public BasicGetResult BasicGet(string queue, bool autoAck)
+    {
+        return this.service.Get(queue, autoAck);
     }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQMessageActions.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQMessageActions.cs
@@ -4,47 +4,34 @@
 using System;
 using System.Threading.Tasks;
 using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
 
 namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ;
 
 public class RabbitMQMessageActions
 {
     private readonly IRabbitMQService service;
+    private readonly BasicDeliverEventArgs message;
 
-    internal RabbitMQMessageActions(IRabbitMQService service)
+    internal RabbitMQMessageActions(IRabbitMQService service, BasicDeliverEventArgs message)
     {
         this.service = service;
+        this.message = message;
     }
 
-    public async Task BasicReject(ulong deliveryTag, bool requeue = false)
+    public async Task Reject(bool requeue = false)
     {
         await Task.Run(() =>
         {
-            this.service.Reject(deliveryTag, requeue, logDetails: string.Empty, throwOnMissing: true);
+            this.service.Reject(this.message.DeliveryTag, requeue, logDetails: $"ConsumerTag: {this.message.ConsumerTag}");
         });
     }
 
-    public async Task BasicAck(ulong deliveryTag, bool multiple = false)
+    public async Task Acknowledge(bool multiple = false)
     {
         await Task.Run(() =>
         {
-            this.service.Acknowledge(deliveryTag, multiple, logDetails: string.Empty, throwOnMissing: true);
-        });
-    }
-
-    public async Task BasicPublish(string exchange, string routingKey, IBasicProperties basicProperties, ReadOnlyMemory<byte> body)
-    {
-        await Task.Run(() =>
-        {
-            this.service.Publish(exchange, routingKey, basicProperties, body);
-        });
-    }
-
-    public async Task<BasicGetResult> BasicGet(string queue, bool autoAck)
-    {
-        return await Task.Run(() =>
-        {
-            return this.service.Get(queue, autoAck);
+            this.service.Acknowledge(this.message.DeliveryTag, multiple, logDetails: $"ConsumerTag: {this.message.ConsumerTag}");
         });
     }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerAttribute.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerAttribute.cs
@@ -35,7 +35,7 @@ public sealed class RabbitMQTriggerAttribute(string queueName) : Attribute
     public bool DisableCertificateValidation { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether message acknowledgements would be done manually.
+    /// Gets or sets a value indicating whether message acknowledgements from service would be disabled and needs to be done manually.
     /// </summary>
-    public bool ManualAck { get; set; }
+    public bool DisableAck { get; set; }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerAttribute.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerAttribute.cs
@@ -33,4 +33,9 @@ public sealed class RabbitMQTriggerAttribute(string queueName) : Attribute
     /// production. Does not apply when SSL is disabled.
     /// </summary>
     public bool DisableCertificateValidation { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether message acknowledgements would be done manually.
+    /// </summary>
+    public bool ManualAck { get; set; }
 }

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
@@ -42,10 +42,11 @@ internal class RabbitMQTriggerAttributeBindingProvider(
         string connectionString = Utility.ResolveConnectionString(attribute.ConnectionStringSetting, this.options.Value.ConnectionString, this.configuration);
         string queueName = this.Resolve(attribute.QueueName) ?? throw new InvalidOperationException("RabbitMQ queue name is missing");
         bool disableCertificateValidation = attribute.DisableCertificateValidation || this.options.Value.DisableCertificateValidation;
+        bool manualAck = attribute.ManualAck;
 
         IRabbitMQService service = this.provider.GetService(connectionString, queueName, disableCertificateValidation);
 
-        return Task.FromResult<ITriggerBinding>(new RabbitMQTriggerBinding(service, queueName, this.logger, parameter.ParameterType, this.options.Value.PrefetchCount, this.drainModeManager));
+        return Task.FromResult<ITriggerBinding>(new RabbitMQTriggerBinding(service, queueName, manualAck, this.logger, parameter.ParameterType, this.options.Value.PrefetchCount, this.drainModeManager));
     }
 
     private string Resolve(string name)

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerAttributeBindingProvider.cs
@@ -42,11 +42,11 @@ internal class RabbitMQTriggerAttributeBindingProvider(
         string connectionString = Utility.ResolveConnectionString(attribute.ConnectionStringSetting, this.options.Value.ConnectionString, this.configuration);
         string queueName = this.Resolve(attribute.QueueName) ?? throw new InvalidOperationException("RabbitMQ queue name is missing");
         bool disableCertificateValidation = attribute.DisableCertificateValidation || this.options.Value.DisableCertificateValidation;
-        bool manualAck = attribute.ManualAck;
+        bool disableAck = attribute.DisableAck;
 
         IRabbitMQService service = this.provider.GetService(connectionString, queueName, disableCertificateValidation);
 
-        return Task.FromResult<ITriggerBinding>(new RabbitMQTriggerBinding(service, queueName, manualAck, this.logger, parameter.ParameterType, this.options.Value.PrefetchCount, this.drainModeManager));
+        return Task.FromResult<ITriggerBinding>(new RabbitMQTriggerBinding(service, queueName, disableAck, this.logger, parameter.ParameterType, this.options.Value.PrefetchCount, this.drainModeManager));
     }
 
     private string Resolve(string name)

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerBinding.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerBinding.cs
@@ -24,6 +24,7 @@ internal class RabbitMQTriggerBinding(IRabbitMQService service, string queueName
     private readonly bool manualAck = manualAck;
     private readonly ushort prefetchCount = prefetchCount;
     private readonly IDrainModeManager drainModeManager = drainModeManager;
+    private readonly RabbitMQMessageActions messageActions = new(service.Model);
 
     public Type TriggerValueType => typeof(BasicDeliverEventArgs);
 
@@ -32,7 +33,7 @@ internal class RabbitMQTriggerBinding(IRabbitMQService service, string queueName
     public Task<ITriggerData> BindAsync(object value, ValueBindingContext context)
     {
         var message = (BasicDeliverEventArgs)value;
-        IReadOnlyDictionary<string, object> bindingData = CreateBindingData(message, new RabbitMQMessageActions(this.service.Model));
+        IReadOnlyDictionary<string, object> bindingData = CreateBindingData(message, this.messageActions);
 
         return Task.FromResult<ITriggerData>(new TriggerData(new BasicDeliverEventArgsValueProvider(message, this.parameterType), bindingData));
     }

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerBinding.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerBinding.cs
@@ -24,7 +24,6 @@ internal class RabbitMQTriggerBinding(IRabbitMQService service, string queueName
     private readonly bool disableAck = disableAck;
     private readonly ushort prefetchCount = prefetchCount;
     private readonly IDrainModeManager drainModeManager = drainModeManager;
-    private readonly RabbitMQMessageActions messageActions = disableAck ? new(service) : null;
 
     public Type TriggerValueType => typeof(BasicDeliverEventArgs);
 
@@ -33,7 +32,7 @@ internal class RabbitMQTriggerBinding(IRabbitMQService service, string queueName
     public Task<ITriggerData> BindAsync(object value, ValueBindingContext context)
     {
         var message = (BasicDeliverEventArgs)value;
-        IReadOnlyDictionary<string, object> bindingData = CreateBindingData(message, this.messageActions);
+        IReadOnlyDictionary<string, object> bindingData = CreateBindingData(message, this.disableAck ? new RabbitMQMessageActions(this.service, message) : null);
 
         return Task.FromResult<ITriggerData>(new TriggerData(new BasicDeliverEventArgsValueProvider(message, this.parameterType), bindingData));
     }

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerBinding.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerBinding.cs
@@ -15,12 +15,13 @@ using RabbitMQ.Client.Events;
 
 namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ;
 
-internal class RabbitMQTriggerBinding(IRabbitMQService service, string queueName, ILogger logger, Type parameterType, ushort prefetchCount, IDrainModeManager drainModeManager) : ITriggerBinding
+internal class RabbitMQTriggerBinding(IRabbitMQService service, string queueName, bool manualAck, ILogger logger, Type parameterType, ushort prefetchCount, IDrainModeManager drainModeManager) : ITriggerBinding
 {
     private readonly IRabbitMQService service = service;
     private readonly ILogger logger = logger;
     private readonly Type parameterType = parameterType;
     private readonly string queueName = queueName;
+    private readonly bool manualAck = manualAck;
     private readonly ushort prefetchCount = prefetchCount;
     private readonly IDrainModeManager drainModeManager = drainModeManager;
 
@@ -31,7 +32,7 @@ internal class RabbitMQTriggerBinding(IRabbitMQService service, string queueName
     public Task<ITriggerData> BindAsync(object value, ValueBindingContext context)
     {
         var message = (BasicDeliverEventArgs)value;
-        IReadOnlyDictionary<string, object> bindingData = CreateBindingData(message);
+        IReadOnlyDictionary<string, object> bindingData = CreateBindingData(message, new RabbitMQMessageActions(this.service.Model));
 
         return Task.FromResult<ITriggerData>(new TriggerData(new BasicDeliverEventArgsValueProvider(message, this.parameterType), bindingData));
     }
@@ -46,6 +47,7 @@ internal class RabbitMQTriggerBinding(IRabbitMQService service, string queueName
             this.logger,
             context.Descriptor.Id,
             this.queueName,
+            this.manualAck,
             this.prefetchCount,
             this.drainModeManager));
     }
@@ -69,12 +71,13 @@ internal class RabbitMQTriggerBinding(IRabbitMQService service, string queueName
             ["RoutingKey"] = typeof(string),
             ["BasicProperties"] = typeof(IBasicProperties),
             ["Body"] = typeof(ReadOnlyMemory<byte>),
+            ["RabbitMQMessageActions"] = typeof(RabbitMQMessageActions),
         };
 
         return contract;
     }
 
-    internal static IReadOnlyDictionary<string, object> CreateBindingData(BasicDeliverEventArgs value)
+    internal static IReadOnlyDictionary<string, object> CreateBindingData(BasicDeliverEventArgs value, RabbitMQMessageActions messageActions)
     {
         var bindingData = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
 
@@ -85,6 +88,7 @@ internal class RabbitMQTriggerBinding(IRabbitMQService service, string queueName
         SafeAddValue(() => bindingData.Add(nameof(value.RoutingKey), value.RoutingKey));
         SafeAddValue(() => bindingData.Add(nameof(value.BasicProperties), value.BasicProperties));
         SafeAddValue(() => bindingData.Add(nameof(value.Body), value.Body));
+        SafeAddValue(() => bindingData.Add(nameof(RabbitMQMessageActions), messageActions));
 
         return bindingData;
     }

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerBinding.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerBinding.cs
@@ -15,13 +15,13 @@ using RabbitMQ.Client.Events;
 
 namespace Microsoft.Azure.WebJobs.Extensions.RabbitMQ;
 
-internal class RabbitMQTriggerBinding(IRabbitMQService service, string queueName, bool manualAck, ILogger logger, Type parameterType, ushort prefetchCount, IDrainModeManager drainModeManager) : ITriggerBinding
+internal class RabbitMQTriggerBinding(IRabbitMQService service, string queueName, bool disableAck, ILogger logger, Type parameterType, ushort prefetchCount, IDrainModeManager drainModeManager) : ITriggerBinding
 {
     private readonly IRabbitMQService service = service;
     private readonly ILogger logger = logger;
     private readonly Type parameterType = parameterType;
     private readonly string queueName = queueName;
-    private readonly bool manualAck = manualAck;
+    private readonly bool disableAck = disableAck;
     private readonly ushort prefetchCount = prefetchCount;
     private readonly IDrainModeManager drainModeManager = drainModeManager;
     private readonly RabbitMQMessageActions messageActions = new(service);
@@ -48,7 +48,7 @@ internal class RabbitMQTriggerBinding(IRabbitMQService service, string queueName
             this.logger,
             context.Descriptor.Id,
             this.queueName,
-            this.manualAck,
+            this.disableAck,
             this.prefetchCount,
             this.drainModeManager));
     }

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerBinding.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerBinding.cs
@@ -24,7 +24,7 @@ internal class RabbitMQTriggerBinding(IRabbitMQService service, string queueName
     private readonly bool disableAck = disableAck;
     private readonly ushort prefetchCount = prefetchCount;
     private readonly IDrainModeManager drainModeManager = drainModeManager;
-    private readonly RabbitMQMessageActions messageActions = new(service);
+    private readonly RabbitMQMessageActions messageActions = disableAck ? new(service) : null;
 
     public Type TriggerValueType => typeof(BasicDeliverEventArgs);
 

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerBinding.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerBinding.cs
@@ -71,7 +71,7 @@ internal class RabbitMQTriggerBinding(IRabbitMQService service, string queueName
             ["RoutingKey"] = typeof(string),
             ["BasicProperties"] = typeof(IBasicProperties),
             ["Body"] = typeof(ReadOnlyMemory<byte>),
-            ["RabbitMQMessageActions"] = typeof(RabbitMQMessageActions),
+            ["MessageActions"] = typeof(RabbitMQMessageActions),
         };
 
         return contract;
@@ -88,7 +88,7 @@ internal class RabbitMQTriggerBinding(IRabbitMQService service, string queueName
         SafeAddValue(() => bindingData.Add(nameof(value.RoutingKey), value.RoutingKey));
         SafeAddValue(() => bindingData.Add(nameof(value.BasicProperties), value.BasicProperties));
         SafeAddValue(() => bindingData.Add(nameof(value.Body), value.Body));
-        SafeAddValue(() => bindingData.Add(nameof(RabbitMQMessageActions), messageActions));
+        SafeAddValue(() => bindingData.Add(nameof(messageActions), messageActions));
 
         return bindingData;
     }

--- a/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerBinding.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ/Trigger/RabbitMQTriggerBinding.cs
@@ -24,7 +24,7 @@ internal class RabbitMQTriggerBinding(IRabbitMQService service, string queueName
     private readonly bool manualAck = manualAck;
     private readonly ushort prefetchCount = prefetchCount;
     private readonly IDrainModeManager drainModeManager = drainModeManager;
-    private readonly RabbitMQMessageActions messageActions = new(service.Model);
+    private readonly RabbitMQMessageActions messageActions = new(service);
 
     public Type TriggerValueType => typeof(BasicDeliverEventArgs);
 
@@ -43,7 +43,7 @@ internal class RabbitMQTriggerBinding(IRabbitMQService service, string queueName
         _ = context ?? throw new ArgumentNullException(nameof(context), "Missing listener context");
 
         return Task.FromResult<IListener>(new RabbitMQListener(
-            this.service.Model,
+            this.service,
             context.Executor,
             this.logger,
             context.Descriptor.Id,


### PR DESCRIPTION
As discussed in the issue https://github.com/Azure/azure-functions-rabbitmq-extension/issues/151

It is common scenario that message ack / reject would need to be done by the function code and not always by the host.
This PR is fixing that problem by introducing a new trigger attribute DisableAck. 
If this attribute is set to true, host would not perform acknowledgements for the processed message and function code need to do it.
The default value of this attribute is false, so existing apps would be working as is. 

Since the Ack/Reject needs to be done on the exact same channel instance which was created by the host, the host share this channel instance encapsulated in a class RabbitMQMessageActions and pass it as trigger binding.

below code is for reference how it can be used.
```
[FunctionName("Function1")]
public void Run([RabbitMQTrigger("test11", ConnectionStringSetting = "rabbitmqconnsetting", DisableAck = true)]string myQueueItem,
    string consumerTag,
    ulong deliveryTag,
    RabbitMQMessageActions messageActions,
    ILogger log)
{
    log.LogInformation($"C# Queue trigger function processed: {myQueueItem}, deliveryTag: {deliveryTag}");
    
    Console.WriteLine("Acknowleding...");
    messageActions.Acknowledge();
}
```

_Note:
Now, since the host is passing the channel instance to the function code, this is currently only supporting in-proc and C# functions only.
for non C# functions DisableAck should be always false._