### PR TITLE
Migrate RabbitMQ E2E image to ACR cache

### DIFF
--- a/extension/WebJobs.Extensions.RabbitMQ.LangEndToEndTests/docker-compose.yml
+++ b/extension/WebJobs.Extensions.RabbitMQ.LangEndToEndTests/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   rabbitmq:
-    image: rabbitmq:3-management
+    image: funcacrcache.azurecr.io/cache/library/rabbitmq:3-management
     container_name: rabbitmq-e2e
     ports:
       - "5672:5672"


### PR DESCRIPTION
Updates the RabbitMQ language end-to-end test docker-compose file to pull RabbitMQ through funcacrcache.azurecr.io instead of Docker Hub, so AzDO builds do not depend on direct Docker Hub access.