### PR TITLE
Build: route package restores through CFS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+NuGet.config

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <clear />
+    <packageSource key="upstream-public">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,19 +79,30 @@ jobs:
               version: 7.0.x
               performMultiLevelLookup: true
 
+          - task: NuGetAuthenticate@1
+            displayName: Authenticate to CFS NuGet feed
+
+          - task: DotNetCoreCLI@2
+            displayName: Restore solution from CFS
+            inputs:
+              command: restore
+              projects: extension/WebJobs.Extensions.RabbitMQ.sln
+              feedsToUse: config
+              nugetConfigPath: NuGet.config
+
           - task: DotNetCoreCLI@2
             displayName: Build solution
             inputs:
               command: build
               workingDirectory: extension
-              arguments: --configuration Release -property:Version=$(fileVersion) -property:CommitHash=$(Build.SourceVersion)
+              arguments: --no-restore --configuration Release -property:Version=$(fileVersion) -property:CommitHash=$(Build.SourceVersion)
 
           - task: DotNetCoreCLI@2
             displayName: Test extension
             inputs:
               command: test
               workingDirectory: extension
-              arguments: --configuration Debug
+              arguments: --no-restore --configuration Debug
 
           - ${{ if eq(variables.isReleaseBuild, 'True') }}:
             - task: EsrpCodeSigning@1

--- a/eng/ci/public-linux-build.yml
+++ b/eng/ci/public-linux-build.yml
@@ -39,7 +39,7 @@ extends:
       skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
     pool:
       name: 1es-pool-azfunc-public
-      image: 1es-ubuntu-24.04-min
+      image: 1es-ubuntu-22.04
       os: linux
     sdl:
       sourceAnalysisPool:
@@ -65,6 +65,12 @@ extends:
         jobs:
           - job: RunE2ETests
             displayName: Run E2E Tests with Docker
+            # The E2E docker image builds need more free disk than the default
+            # image has, so run this job on the minimal image.
+            pool:
+              name: 1es-pool-azfunc-public
+              image: 1es-ubuntu-24.04-min
+              os: linux
             steps:
               - template: /eng/ci/templates/shared/run-e2e-tests.yml@self
 

--- a/eng/ci/public-linux-build.yml
+++ b/eng/ci/public-linux-build.yml
@@ -39,7 +39,7 @@ extends:
       skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
     pool:
       name: 1es-pool-azfunc-public
-      image: 1es-ubuntu-22.04
+      image: 1es-ubuntu-24.04-min
       os: linux
     sdl:
       sourceAnalysisPool:

--- a/eng/ci/scripts/prepare-cfs-docker-build.ps1
+++ b/eng/ci/scripts/prepare-cfs-docker-build.ps1
@@ -16,6 +16,8 @@ $ErrorActionPreference = 'Stop'
 
 $npmRegistry = 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/'
 $nugetRegistry = 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json'
+$canonicalPipIndexPath = '/azfunc/public/_packaging/upstream-public/pypi/simple/'
+$legacyPipIndexPath = '/public/_packaging/upstream-public/pypi/simple/'
 $repositoryRootPath = [System.IO.Path]::GetFullPath($RepositoryRoot)
 $outputDirectoryPath = [System.IO.Path]::GetFullPath($OutputDirectory)
 
@@ -48,6 +50,34 @@ function ConvertTo-YamlSingleQuotedString([string] $Value) {
 
 function Write-Utf8File([string] $Path, [string] $Content) {
     [System.IO.File]::WriteAllText($Path, $Content, [System.Text.UTF8Encoding]::new($false))
+}
+
+function ConvertTo-CfsPipIndexUrl([string] $PipIndexUrl) {
+    $uri = [System.Uri] $PipIndexUrl
+    $isCanonicalUrl = $uri.Host -eq 'pkgs.dev.azure.com' -and $uri.AbsolutePath -eq $canonicalPipIndexPath
+    $isLegacyTaskUrl = $uri.Host -eq 'azfunc.pkgs.visualstudio.com' -and $uri.AbsolutePath -eq $legacyPipIndexPath
+
+    if ($uri.Scheme -ne 'https' -or
+        -not $uri.IsDefaultPort -or
+        -not [string]::IsNullOrEmpty($uri.Query) -or
+        -not [string]::IsNullOrEmpty($uri.Fragment) -or
+        (-not $isCanonicalUrl -and -not $isLegacyTaskUrl)) {
+        throw 'PIP_INDEX_URL does not target the azfunc/public/upstream-public feed.'
+    }
+
+    if ($isCanonicalUrl) {
+        return $PipIndexUrl
+    }
+
+    $userInfo = $uri.GetComponents([System.UriComponents]::UserInfo, [System.UriFormat]::UriEscaped)
+    $authority = if ([string]::IsNullOrEmpty($userInfo)) {
+        'pkgs.dev.azure.com'
+    }
+    else {
+        "$userInfo@pkgs.dev.azure.com"
+    }
+
+    return "https://$authority$canonicalPipIndexPath"
 }
 
 function New-NuGetConfig([string] $Path, [string] $AccessToken) {
@@ -210,11 +240,7 @@ registry=$npmRegistry
             throw 'PipAuthenticate@1 did not set PIP_INDEX_URL.'
         }
 
-        $pipIndexUri = [System.Uri] $pipIndexUrl
-        if ($pipIndexUri.Host -ne 'pkgs.dev.azure.com' -or
-            -not $pipIndexUri.AbsolutePath.Contains('/azfunc/public/_packaging/upstream-public/pypi/simple/')) {
-            throw 'PIP_INDEX_URL does not target the azfunc/public/upstream-public feed.'
-        }
+        $pipIndexUrl = ConvertTo-CfsPipIndexUrl $pipIndexUrl
 
         $nugetAccessToken = $env:VSS_NUGET_ACCESSTOKEN
         if ([string]::IsNullOrWhiteSpace($nugetAccessToken)) {

--- a/eng/ci/scripts/prepare-cfs-docker-build.ps1
+++ b/eng/ci/scripts/prepare-cfs-docker-build.ps1
@@ -17,7 +17,7 @@ $ErrorActionPreference = 'Stop'
 $npmRegistry = 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/'
 $nugetRegistry = 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json'
 $canonicalPipIndexPath = '/azfunc/public/_packaging/upstream-public/pypi/simple/'
-$legacyPipIndexPath = '/public/_packaging/upstream-public/pypi/simple/'
+$legacyPipIndexPath = '/public/_packaging/upstream-public/pypi/simple'
 $repositoryRootPath = [System.IO.Path]::GetFullPath($RepositoryRoot)
 $outputDirectoryPath = [System.IO.Path]::GetFullPath($OutputDirectory)
 
@@ -54,8 +54,10 @@ function Write-Utf8File([string] $Path, [string] $Content) {
 
 function ConvertTo-CfsPipIndexUrl([string] $PipIndexUrl) {
     $uri = [System.Uri] $PipIndexUrl
-    $isCanonicalUrl = $uri.Host -eq 'pkgs.dev.azure.com' -and $uri.AbsolutePath -eq $canonicalPipIndexPath
-    $isLegacyTaskUrl = $uri.Host -eq 'azfunc.pkgs.visualstudio.com' -and $uri.AbsolutePath -eq $legacyPipIndexPath
+    $isCanonicalUrl = $uri.Host -eq 'pkgs.dev.azure.com' -and
+        $uri.AbsolutePath -in @($canonicalPipIndexPath, $canonicalPipIndexPath.TrimEnd('/'))
+    $isLegacyTaskUrl = $uri.Host -eq 'azfunc.pkgs.visualstudio.com' -and
+        $uri.AbsolutePath -in @($legacyPipIndexPath, "$legacyPipIndexPath/")
 
     if ($uri.Scheme -ne 'https' -or
         -not $uri.IsDefaultPort -or
@@ -65,7 +67,7 @@ function ConvertTo-CfsPipIndexUrl([string] $PipIndexUrl) {
         throw 'PIP_INDEX_URL does not target the azfunc/public/upstream-public feed.'
     }
 
-    if ($isCanonicalUrl) {
+    if ($uri.Host -eq 'pkgs.dev.azure.com' -and $uri.AbsolutePath -eq $canonicalPipIndexPath) {
         return $PipIndexUrl
     }
 

--- a/eng/ci/scripts/prepare-cfs-docker-build.ps1
+++ b/eng/ci/scripts/prepare-cfs-docker-build.ps1
@@ -1,0 +1,279 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateSet('Initialize', 'Finalize', 'Cleanup')]
+    [string] $Phase,
+
+    [Parameter(Mandatory)]
+    [string] $RepositoryRoot,
+
+    [Parameter(Mandatory)]
+    [string] $OutputDirectory
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$npmRegistry = 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/'
+$nugetRegistry = 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json'
+$repositoryRootPath = [System.IO.Path]::GetFullPath($RepositoryRoot)
+$outputDirectoryPath = [System.IO.Path]::GetFullPath($OutputDirectory)
+
+function Assert-SafeOutputDirectory {
+    $root = [System.IO.Path]::GetPathRoot($outputDirectoryPath)
+    if ([string]::IsNullOrWhiteSpace($outputDirectoryPath) -or
+        $outputDirectoryPath -eq $root -or
+        $outputDirectoryPath -eq $repositoryRootPath -or
+        [System.IO.Path]::GetFileName($outputDirectoryPath) -ne 'rabbitmq cfs e2e') {
+        throw "Unsafe CFS output directory '$outputDirectoryPath'."
+    }
+}
+
+function Set-AzurePipelinesVariable([string] $Name, [string] $Value) {
+    Write-Host "##vso[task.setvariable variable=$Name]$Value"
+}
+
+function Replace-ExactlyOnce([string] $Content, [string] $OldValue, [string] $NewValue, [string] $Description) {
+    $matchCount = ([regex]::Matches($Content, [regex]::Escape($OldValue))).Count
+    if ($matchCount -ne 1) {
+        throw "Expected one $Description in the Dockerfile, but found $matchCount."
+    }
+
+    return $Content.Replace($OldValue, $NewValue)
+}
+
+function ConvertTo-YamlSingleQuotedString([string] $Value) {
+    return "'$($Value.Replace("'", "''"))'"
+}
+
+function Write-Utf8File([string] $Path, [string] $Content) {
+    [System.IO.File]::WriteAllText($Path, $Content, [System.Text.UTF8Encoding]::new($false))
+}
+
+function New-NuGetConfig([string] $Path, [string] $AccessToken) {
+    $settings = [System.Xml.XmlWriterSettings]::new()
+    $settings.Indent = $true
+    $settings.Encoding = [System.Text.UTF8Encoding]::new($false)
+
+    $writer = [System.Xml.XmlWriter]::Create($Path, $settings)
+    try {
+        $writer.WriteStartDocument()
+        $writer.WriteStartElement('configuration')
+
+        $writer.WriteStartElement('packageSources')
+        $writer.WriteElementString('clear', '')
+        $writer.WriteStartElement('add')
+        $writer.WriteAttributeString('key', 'upstream-public')
+        $writer.WriteAttributeString('value', $nugetRegistry)
+        $writer.WriteEndElement()
+        $writer.WriteStartElement('add')
+        $writer.WriteAttributeString('key', 'Local')
+        $writer.WriteAttributeString('value', '/workspace/temp')
+        $writer.WriteEndElement()
+        $writer.WriteEndElement()
+
+        $writer.WriteStartElement('packageSourceMapping')
+        $writer.WriteElementString('clear', '')
+        $writer.WriteStartElement('packageSource')
+        $writer.WriteAttributeString('key', 'upstream-public')
+        $writer.WriteStartElement('package')
+        $writer.WriteAttributeString('pattern', '*')
+        $writer.WriteEndElement()
+        $writer.WriteEndElement()
+        $writer.WriteStartElement('packageSource')
+        $writer.WriteAttributeString('key', 'Local')
+        $writer.WriteStartElement('package')
+        $writer.WriteAttributeString('pattern', 'Microsoft.Azure.WebJobs.Extensions.RabbitMQ')
+        $writer.WriteEndElement()
+        $writer.WriteEndElement()
+        $writer.WriteEndElement()
+
+        $writer.WriteStartElement('packageSourceCredentials')
+        $writer.WriteStartElement('upstream-public')
+        $writer.WriteStartElement('add')
+        $writer.WriteAttributeString('key', 'Username')
+        $writer.WriteAttributeString('value', 'AzureDevOps')
+        $writer.WriteEndElement()
+        $writer.WriteStartElement('add')
+        $writer.WriteAttributeString('key', 'ClearTextPassword')
+        $writer.WriteAttributeString('value', $AccessToken)
+        $writer.WriteEndElement()
+        $writer.WriteEndElement()
+        $writer.WriteEndElement()
+
+        $writer.WriteEndElement()
+        $writer.WriteEndDocument()
+    }
+    finally {
+        $writer.Dispose()
+    }
+}
+
+function New-CfsDockerfile([string] $SourcePath, [string] $DestinationPath, [bool] $IsPython) {
+    $content = (Get-Content -LiteralPath $SourcePath -Raw).Replace("`r`n", "`n")
+    $functionApp = if ($IsPython) { 'python' } else { 'java' }
+    $functionAppsPath = '/workspace/extension/WebJobs.Extensions.RabbitMQ.LangEndToEndTests/FunctionApps'
+    $content = Replace-ExactlyOnce $content `
+        "RUN mkdir /workspace`nCOPY . /workspace" `
+        @"
+RUN mkdir -p /workspace/temp $functionAppsPath
+COPY temp /workspace/temp
+COPY extension/WebJobs.Extensions.RabbitMQ.LangEndToEndTests/FunctionApps/$functionApp $functionAppsPath/$functionApp
+"@ `
+        'workspace copy'
+    $content = Replace-ExactlyOnce $content `
+        'RUN npm install -g azure-functions-core-tools@4 --unsafe-perm true' `
+        @'
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=true \
+    NPM_CONFIG_USERCONFIG=/root/.npmrc npm install -g azure-functions-core-tools@4 --unsafe-perm true
+'@ `
+        'Azure Functions Core Tools npm install'
+    $content = Replace-ExactlyOnce $content `
+        'RUN dotnet nuget add source /workspace/temp --name Local && dotnet nuget list source' `
+        @'
+RUN --mount=type=secret,id=nuget_config,target=/workspace/NuGet.config,required=true \
+    dotnet nuget list source --configfile /workspace/NuGet.config
+'@ `
+        'local NuGet source setup'
+
+    if ($IsPython) {
+        $content = Replace-ExactlyOnce $content `
+            'RUN python3 -m pip install --upgrade pip --break-system-packages' `
+            @'
+RUN --mount=type=secret,id=pip_index_url,target=/run/secrets/pip_index_url,required=true \
+    PIP_INDEX_URL="$(cat /run/secrets/pip_index_url)" python3 -m pip install --upgrade pip --break-system-packages
+'@ `
+            'pip upgrade'
+        $content = Replace-ExactlyOnce $content `
+            'RUN pip3 install -r requirements.txt --break-system-packages' `
+            @'
+RUN --mount=type=secret,id=pip_index_url,target=/run/secrets/pip_index_url,required=true \
+    PIP_INDEX_URL="$(cat /run/secrets/pip_index_url)" pip3 install -r requirements.txt --break-system-packages
+'@ `
+            'Python requirements install'
+        $content = Replace-ExactlyOnce $content `
+            'RUN dotnet build extensions.csproj -o bin' `
+            @'
+RUN --mount=type=secret,id=nuget_config,target=/workspace/NuGet.config,required=true \
+    dotnet restore extensions.csproj --configfile /workspace/NuGet.config
+RUN dotnet build extensions.csproj -o bin --no-restore
+RUN rm -f /root/.nuget/NuGet/NuGet.Config
+'@ `
+            'Python extension build'
+    }
+    else {
+        $content = Replace-ExactlyOnce $content `
+            'RUN mvn clean package -DskipTests' `
+            @'
+RUN --mount=type=secret,id=nuget_config,target=/workspace/NuGet.config,required=true \
+    mvn clean package -DskipTests
+RUN rm -f /root/.nuget/NuGet/NuGet.Config
+'@ `
+            'Java function app build'
+    }
+
+    Write-Utf8File $DestinationPath $content
+}
+
+Assert-SafeOutputDirectory
+
+switch ($Phase) {
+    'Initialize' {
+        if (Test-Path -LiteralPath $outputDirectoryPath) {
+            Remove-Item -LiteralPath $outputDirectoryPath -Recurse -Force
+        }
+
+        New-Item -ItemType Directory -Path $outputDirectoryPath | Out-Null
+        $npmConfigPath = Join-Path $outputDirectoryPath '.npmrc'
+        Write-Utf8File $npmConfigPath @"
+registry=$npmRegistry
+@types:registry=$npmRegistry
+"@
+
+        Set-AzurePipelinesVariable 'cfsTempDirectory' $outputDirectoryPath
+        Set-AzurePipelinesVariable 'cfsNpmConfig' $npmConfigPath
+    }
+
+    'Finalize' {
+        $npmConfigPath = Join-Path $outputDirectoryPath '.npmrc'
+        if (-not (Test-Path -LiteralPath $npmConfigPath)) {
+            throw "The temporary npm configuration '$npmConfigPath' does not exist."
+        }
+
+        $npmConfig = Get-Content -LiteralPath $npmConfigPath -Raw
+        if ($npmConfig -notmatch '(?m):(_authToken|_password)=') {
+            throw 'npmAuthenticate@0 did not add credentials to the temporary npm configuration.'
+        }
+
+        $pipIndexUrl = $env:PIP_INDEX_URL
+        if ([string]::IsNullOrWhiteSpace($pipIndexUrl)) {
+            throw 'PipAuthenticate@1 did not set PIP_INDEX_URL.'
+        }
+
+        $pipIndexUri = [System.Uri] $pipIndexUrl
+        if ($pipIndexUri.Host -ne 'pkgs.dev.azure.com' -or
+            -not $pipIndexUri.AbsolutePath.Contains('/azfunc/public/_packaging/upstream-public/pypi/simple/')) {
+            throw 'PIP_INDEX_URL does not target the azfunc/public/upstream-public feed.'
+        }
+
+        $nugetAccessToken = $env:VSS_NUGET_ACCESSTOKEN
+        if ([string]::IsNullOrWhiteSpace($nugetAccessToken)) {
+            throw 'NuGetAuthenticate@1 did not set VSS_NUGET_ACCESSTOKEN.'
+        }
+
+        $nugetConfigPath = Join-Path $outputDirectoryPath 'NuGet.config'
+        $pipIndexPath = Join-Path $outputDirectoryPath 'pip-index-url'
+        $javaDockerfilePath = Join-Path $outputDirectoryPath 'java.Dockerfile'
+        $pythonDockerfilePath = Join-Path $outputDirectoryPath 'python.Dockerfile'
+        $composeOverridePath = Join-Path $outputDirectoryPath 'docker-compose.cfs.yml'
+
+        New-NuGetConfig $nugetConfigPath $nugetAccessToken
+        Write-Utf8File $pipIndexPath $pipIndexUrl
+        New-CfsDockerfile `
+            (Join-Path $repositoryRootPath 'extension/WebJobs.Extensions.RabbitMQ.LangEndToEndTests/FunctionApps/java/Dockerfile') `
+            $javaDockerfilePath `
+            $false
+        New-CfsDockerfile `
+            (Join-Path $repositoryRootPath 'extension/WebJobs.Extensions.RabbitMQ.LangEndToEndTests/FunctionApps/python/Dockerfile') `
+            $pythonDockerfilePath `
+            $true
+
+        $javaDockerfile = ConvertTo-YamlSingleQuotedString $javaDockerfilePath
+        $pythonDockerfile = ConvertTo-YamlSingleQuotedString $pythonDockerfilePath
+        $npmConfig = ConvertTo-YamlSingleQuotedString $npmConfigPath
+        $nugetConfig = ConvertTo-YamlSingleQuotedString $nugetConfigPath
+        $pipIndex = ConvertTo-YamlSingleQuotedString $pipIndexPath
+        Write-Utf8File $composeOverridePath @"
+services:
+  java-app:
+    build:
+      dockerfile: $javaDockerfile
+      secrets:
+        - npmrc
+        - nuget_config
+  python-app:
+    build:
+      dockerfile: $pythonDockerfile
+      secrets:
+        - npmrc
+        - nuget_config
+        - pip_index_url
+
+secrets:
+  npmrc:
+    file: $npmConfig
+  nuget_config:
+    file: $nugetConfig
+  pip_index_url:
+    file: $pipIndex
+"@
+
+        Set-AzurePipelinesVariable 'cfsDockerComposeOverride' $composeOverridePath
+    }
+
+    'Cleanup' {
+        if (Test-Path -LiteralPath $outputDirectoryPath) {
+            Remove-Item -LiteralPath $outputDirectoryPath -Recurse -Force
+        }
+    }
+}

--- a/eng/ci/templates/official/build-extension.yml
+++ b/eng/ci/templates/official/build-extension.yml
@@ -49,19 +49,30 @@ jobs:
           version: 8.0.x
           performMultiLevelLookup: true
 
+      - task: NuGetAuthenticate@1
+        displayName: Authenticate to CFS NuGet feed
+
+      - task: DotNetCoreCLI@2
+        displayName: Restore solution from CFS
+        inputs:
+          command: restore
+          projects: extension/WebJobs.Extensions.RabbitMQ.sln
+          feedsToUse: config
+          nugetConfigPath: NuGet.config
+
       - task: DotNetCoreCLI@2
         displayName: Build solution
         inputs:
           command: build
           workingDirectory: extension
-          arguments: --configuration Release -property:Version=$(fileVersion) -property:CommitHash=$(Build.SourceVersion)
+          arguments: --no-restore --configuration Release -property:Version=$(fileVersion) -property:CommitHash=$(Build.SourceVersion)
 
       - task: DotNetCoreCLI@2
         displayName: Test extension
         inputs:
           command: test
           workingDirectory: extension
-          arguments: --configuration Debug
+          arguments: --no-restore --configuration Debug
 
       - template: ci/sign-files.yml@eng
         parameters:

--- a/eng/ci/templates/public/build-test-extension.yml
+++ b/eng/ci/templates/public/build-test-extension.yml
@@ -15,12 +15,23 @@ jobs:
           version: 8.0.x
           performMultiLevelLookup: true
 
+      - task: NuGetAuthenticate@1
+        displayName: Authenticate to CFS NuGet feed
+
+      - task: DotNetCoreCLI@2
+        displayName: Restore solution from CFS
+        inputs:
+          command: restore
+          projects: extension/WebJobs.Extensions.RabbitMQ.sln
+          feedsToUse: config
+          nugetConfigPath: NuGet.config
+
       - task: DotNetCoreCLI@2
         displayName: Build solution
         inputs:
           command: build
           workingDirectory: extension
-          arguments: --configuration Release -property:Version=$(fileVersion) -property:CommitHash=$(Build.SourceVersion)
+          arguments: --no-restore --configuration Release -property:Version=$(fileVersion) -property:CommitHash=$(Build.SourceVersion)
 
       - task: DotNetCoreCLI@2
         displayName: Test extension
@@ -28,4 +39,4 @@ jobs:
           command: test
           projects: |
             extension/WebJobs.Extensions.RabbitMQ.Tests/WebJobs.Extensions.RabbitMQ.Tests.csproj
-          arguments: --configuration Debug
+          arguments: --no-restore --configuration Debug

--- a/eng/ci/templates/shared/run-e2e-tests.yml
+++ b/eng/ci/templates/shared/run-e2e-tests.yml
@@ -161,6 +161,8 @@ steps:
       CFS_DOCKER_COMPOSE_OVERRIDE: $(cfsDockerComposeOverride)
       DOCKER_BUILDKIT: 1
       DOCKER_HOST: unix:///var/run/docker.sock
+      # Surface the full docker build output so image build failures are diagnosable.
+      BUILDKIT_PROGRESS: plain
 
   - script: |
       echo "E2E tests were skipped because Docker is not available on this agent."

--- a/eng/ci/templates/shared/run-e2e-tests.yml
+++ b/eng/ci/templates/shared/run-e2e-tests.yml
@@ -89,6 +89,19 @@ steps:
     displayName: Check Docker availability
     name: dockerCheck
 
+  # The minimal agent image ships Docker Engine but not Compose. The Lang E2E
+  # fixture shells out to `docker compose`, so install the v2 plugin from the
+  # Ubuntu archive (reachable on the isolated agents).
+  - script: |
+      if ! docker compose version >/dev/null 2>&1; then
+        echo "Docker Compose not found; installing docker-compose-v2..."
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends docker-compose-v2
+      fi
+      docker compose version
+    displayName: Ensure Docker Compose is available
+    condition: and(succeeded(), eq(variables['dockerAvailable'], 'true'))
+
   - task: PowerShell@2
     displayName: Prepare authenticated CFS Docker build
     condition: and(succeeded(), eq(variables['dockerAvailable'], 'true'))

--- a/eng/ci/templates/shared/run-e2e-tests.yml
+++ b/eng/ci/templates/shared/run-e2e-tests.yml
@@ -10,12 +10,48 @@ parameters:
     displayName: 'Optional test filter expression'
 
 steps:
+  - task: NuGetAuthenticate@1
+    displayName: Authenticate to CFS NuGet feed
+
+  - task: PowerShell@2
+    displayName: Initialize temporary CFS Docker configuration
+    inputs:
+      pwsh: true
+      targetType: inline
+      script: |
+        & "$(Build.SourcesDirectory)/eng/ci/scripts/prepare-cfs-docker-build.ps1" `
+          -Phase Initialize `
+          -RepositoryRoot "$(Build.SourcesDirectory)" `
+          -OutputDirectory "$(Agent.TempDirectory)/rabbitmq cfs e2e"
+
+  - task: npmAuthenticate@0
+    displayName: Authenticate to CFS npm feed
+    inputs:
+      workingFile: $(cfsNpmConfig)
+
+  - task: PipAuthenticate@1
+    displayName: Authenticate to CFS PyPI feed
+    inputs:
+      artifactFeeds: public/upstream-public
+      onlyAddExtraIndex: false
+
   - task: UseDotNet@2
     displayName: Acquire .NET 8.0 SDK
     inputs:
       packageType: sdk
       version: 8.0.x
       performMultiLevelLookup: true
+
+  - task: DotNetCoreCLI@2
+    displayName: Restore E2E projects from CFS
+    inputs:
+      command: restore
+      projects: |
+        extension/WebJobs.Extensions.RabbitMQ/WebJobs.Extensions.RabbitMQ.csproj
+        extension/WebJobs.Extensions.RabbitMQ.EndToEndTests/WebJobs.Extensions.RabbitMQ.EndToEndTests.csproj
+        extension/WebJobs.Extensions.RabbitMQ.LangEndToEndTests/WebJobs.Extensions.RabbitMQ.LangEndToEndTests.csproj
+      feedsToUse: config
+      nugetConfigPath: NuGet.config
 
   # Build the extension and create NuGet package for LangEndToEndTests
   # The Docker containers need a local NuGet source with the extension package
@@ -24,7 +60,7 @@ steps:
     inputs:
       command: build
       projects: 'extension/WebJobs.Extensions.RabbitMQ/WebJobs.Extensions.RabbitMQ.csproj'
-      arguments: '--configuration Release'
+      arguments: '--no-restore --configuration Release'
 
   - task: DotNetCoreCLI@2
     displayName: Pack Extension for E2E Tests
@@ -52,6 +88,18 @@ steps:
       fi
     displayName: Check Docker availability
     name: dockerCheck
+
+  - task: PowerShell@2
+    displayName: Prepare authenticated CFS Docker build
+    condition: and(succeeded(), eq(variables['dockerAvailable'], 'true'))
+    inputs:
+      pwsh: true
+      targetType: inline
+      script: |
+        & "$(Build.SourcesDirectory)/eng/ci/scripts/prepare-cfs-docker-build.ps1" `
+          -Phase Finalize `
+          -RepositoryRoot "$(Build.SourcesDirectory)" `
+          -OutputDirectory "$(cfsTempDirectory)"
 
   # Pre-pull Docker images with retry to avoid Docker Hub rate limit issues
   # This helps when running on shared CI agents where rate limits may be exhausted
@@ -90,7 +138,7 @@ steps:
     inputs:
       command: test
       projects: 'extension/WebJobs.Extensions.RabbitMQ.EndToEndTests/WebJobs.Extensions.RabbitMQ.EndToEndTests.csproj'
-      arguments: '--configuration Release --logger trx ${{ parameters.testFilter }}'
+      arguments: '--no-restore --configuration Release --logger trx ${{ parameters.testFilter }}'
       publishTestResults: true
     env:
       DOCKER_HOST: unix:///var/run/docker.sock
@@ -101,9 +149,11 @@ steps:
     inputs:
       command: test
       projects: 'extension/WebJobs.Extensions.RabbitMQ.LangEndToEndTests/WebJobs.Extensions.RabbitMQ.LangEndToEndTests.csproj'
-      arguments: '--configuration Release --logger trx --filter "Category!=DockerCompose" ${{ parameters.testFilter }}'
+      arguments: '--no-restore --configuration Release --logger trx --filter "Category!=DockerCompose" ${{ parameters.testFilter }}'
       publishTestResults: true
     env:
+      CFS_DOCKER_COMPOSE_OVERRIDE: $(cfsDockerComposeOverride)
+      DOCKER_BUILDKIT: 1
       DOCKER_HOST: unix:///var/run/docker.sock
 
   - script: |
@@ -111,3 +161,15 @@ steps:
       echo "To run E2E tests locally, ensure Docker Desktop is running."
     displayName: E2E Tests Skipped Notice
     condition: and(succeeded(), eq(variables['dockerAvailable'], 'false'))
+
+  - task: PowerShell@2
+    displayName: Remove temporary CFS Docker configuration
+    condition: always()
+    inputs:
+      pwsh: true
+      targetType: inline
+      script: |
+        & "$(Build.SourcesDirectory)/eng/ci/scripts/prepare-cfs-docker-build.ps1" `
+          -Phase Cleanup `
+          -RepositoryRoot "$(Build.SourcesDirectory)" `
+          -OutputDirectory "$(cfsTempDirectory)"

--- a/eng/ci/templates/shared/run-e2e-tests.yml
+++ b/eng/ci/templates/shared/run-e2e-tests.yml
@@ -108,7 +108,7 @@ steps:
       MAX_RETRIES=3
       RETRY_DELAY=30
       
-      for image in "rabbitmq:3-management-alpine" "mcr.microsoft.com/azure-storage/azurite"; do
+      for image in "mcr.microsoft.com/mirror/docker/library/rabbitmq:3-management-alpine" "mcr.microsoft.com/azure-storage/azurite"; do
         echo "Pulling $image..."
         for i in $(seq 1 $MAX_RETRIES); do
           if docker pull "$image"; then
@@ -142,6 +142,12 @@ steps:
       publishTestResults: true
     env:
       DOCKER_HOST: unix:///var/run/docker.sock
+      # Isolated agents cannot reach Docker Hub (registry-1.docker.io); pull the
+      # RabbitMQ image from the anonymous MCR Docker Hub mirror instead.
+      RABBITMQ_TEST_IMAGE: mcr.microsoft.com/mirror/docker/library/rabbitmq:3-management-alpine
+      # Ryuk pulls testcontainers/ryuk from Docker Hub, which is unreachable here.
+      # Disable it; CI agents are ephemeral, so container cleanup is not needed.
+      TESTCONTAINERS_RYUK_DISABLED: 'true'
 
   - task: DotNetCoreCLI@2
     displayName: Run Multi-Language E2E Tests (Java/Python)

--- a/extension/WebJobs.Extensions.RabbitMQ.EndToEndTests/RabbitMQEndToEndTestFixture.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.EndToEndTests/RabbitMQEndToEndTestFixture.cs
@@ -26,8 +26,15 @@ public sealed class RabbitMQEndToEndTestFixture : IAsyncLifetime
 
     public RabbitMQEndToEndTestFixture()
     {
+        // Allow CI to override the image so it can be pulled from a mirror (e.g. the MCR
+        // Docker Hub mirror) on network-isolated agents that cannot reach Docker Hub
+        // directly. Defaults to Docker Hub for local runs.
+        var rabbitMqImage = Environment.GetEnvironmentVariable("RABBITMQ_TEST_IMAGE") is { Length: > 0 } image
+            ? image
+            : "rabbitmq:3-management-alpine";
+
         _rabbitMqContainer = new RabbitMqBuilder()
-            .WithImage("rabbitmq:3-management-alpine")
+            .WithImage(rabbitMqImage)
             .WithUsername("guest")
             .WithPassword("guest")
             .WithPortBinding(5672, true)

--- a/extension/WebJobs.Extensions.RabbitMQ.LangEndToEndTests/FunctionApps/java/Dockerfile
+++ b/extension/WebJobs.Extensions.RabbitMQ.LangEndToEndTests/FunctionApps/java/Dockerfile
@@ -1,7 +1,7 @@
 # The isolated CI agents cannot reach Docker Hub, NodeSource, Adoptium, or the
-# Debian apt repos. The Microsoft Java dev container image is built on the
-# Microsoft Build of OpenJDK 21 and bundles Maven on Debian bookworm, so use it
-# as the base and copy in the .NET SDK and Node.js from MCR images.
+# Debian apt repos. The Microsoft Java dev container provides the Microsoft Build
+# of OpenJDK 21 on Debian bookworm; use it as the base, copy the .NET SDK and
+# Node.js from MCR images, and install Maven from Maven Central.
 FROM mcr.microsoft.com/mirror/docker/library/node:20-bookworm-slim AS node
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS dotnet
@@ -25,10 +25,12 @@ COPY --from=dotnet /usr/share/dotnet /usr/share/dotnet
 RUN ln -sf /usr/share/dotnet/dotnet /usr/local/bin/dotnet
 ENV DOTNET_ROOT=/usr/share/dotnet
 
-# The dev container installs Maven via SDKMAN, which only wires it onto PATH in an
-# interactive shell. Symlink the mvn binary onto the system PATH for the build
-# (Java is located via JAVA_HOME, which the base image already sets).
-RUN ln -sf "$(ls -d /usr/local/sdkman/candidates/maven/*/bin/mvn | grep -v /current/ | head -1)" /usr/local/bin/mvn \
+# The dev container ships the Microsoft Build of OpenJDK but not Maven. Install
+# Maven from Maven Central (which the build needs anyway) and put it on PATH.
+# Java is located via JAVA_HOME, which the base image already sets.
+RUN curl -fsSL https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.tar.gz \
+    | tar -xz -C /opt \
+    && ln -sf /opt/apache-maven-3.9.9/bin/mvn /usr/local/bin/mvn \
     && mvn -version
 
 # Install Azure Functions Core Tools via npm (uses .NET 8)

--- a/extension/WebJobs.Extensions.RabbitMQ.LangEndToEndTests/FunctionApps/java/Dockerfile
+++ b/extension/WebJobs.Extensions.RabbitMQ.LangEndToEndTests/FunctionApps/java/Dockerfile
@@ -1,7 +1,9 @@
 # The isolated CI agents cannot reach Docker Hub, NodeSource, Adoptium, or the
 # Debian apt repos. The Microsoft Java dev container image is built on the
-# Microsoft Build of OpenJDK 21 and bundles Maven and Node.js on Debian bookworm,
-# so use it as the base and copy in only the .NET SDK (to build the extension).
+# Microsoft Build of OpenJDK 21 and bundles Maven on Debian bookworm, so use it
+# as the base and copy in the .NET SDK and Node.js from MCR images.
+FROM mcr.microsoft.com/mirror/docker/library/node:20-bookworm-slim AS node
+
 FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS dotnet
 
 FROM mcr.microsoft.com/devcontainers/java:dev-21-bookworm
@@ -9,6 +11,14 @@ FROM mcr.microsoft.com/devcontainers/java:dev-21-bookworm
 # The dev container image defaults to a non-root user; the build steps below
 # write to system locations, so run them as root.
 USER root
+
+# Bring in Node.js from the mirror stage. The dev container's node is managed by
+# nvm and is not on PATH in a non-interactive build step, so provide a system one.
+COPY --from=node /usr/local/bin/node /usr/local/bin/node
+COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+ENV PATH="/usr/local/bin:${PATH}"
 
 # Bring in the .NET 8 SDK
 COPY --from=dotnet /usr/share/dotnet /usr/share/dotnet

--- a/extension/WebJobs.Extensions.RabbitMQ.LangEndToEndTests/FunctionApps/java/Dockerfile
+++ b/extension/WebJobs.Extensions.RabbitMQ.LangEndToEndTests/FunctionApps/java/Dockerfile
@@ -1,17 +1,19 @@
-# Use .NET 8 SDK as base with Node.js for npm install of Core Tools
-FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim
+# The isolated CI agents cannot reach Docker Hub, NodeSource, Adoptium, or the
+# Debian apt repos. The Microsoft Java dev container image is built on the
+# Microsoft Build of OpenJDK 21 and bundles Maven and Node.js on Debian bookworm,
+# so use it as the base and copy in only the .NET SDK (to build the extension).
+FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS dotnet
 
-# Install Node.js and Java 21 (Temurin)
-RUN apt-get update && \
-    apt-get install -y curl gnupg maven && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs && \
-    # Add Adoptium repository for Temurin JDK
-    curl -fsSL https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor -o /usr/share/keyrings/adoptium.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb $(. /etc/os-release && echo $VERSION_CODENAME) main" | tee /etc/apt/sources.list.d/adoptium.list && \
-    apt-get update && \
-    apt-get install -y temurin-21-jdk && \
-    rm -rf /var/lib/apt/lists/*
+FROM mcr.microsoft.com/devcontainers/java:dev-21-bookworm
+
+# The dev container image defaults to a non-root user; the build steps below
+# write to system locations, so run them as root.
+USER root
+
+# Bring in the .NET 8 SDK
+COPY --from=dotnet /usr/share/dotnet /usr/share/dotnet
+RUN ln -sf /usr/share/dotnet/dotnet /usr/local/bin/dotnet
+ENV DOTNET_ROOT=/usr/share/dotnet
 
 # Install Azure Functions Core Tools via npm (uses .NET 8)
 RUN npm install -g azure-functions-core-tools@4 --unsafe-perm true
@@ -30,10 +32,6 @@ RUN dotnet nuget add source /workspace/temp --name Local && dotnet nuget list so
 # Build the Java function app (this will also build extensions)
 RUN mvn clean package -DskipTests
 
-# Set environment
-ENV JAVA_HOME=/usr/lib/jvm/temurin-21-jdk-amd64
-ENV PATH="${JAVA_HOME}/bin:${PATH}"
-
 WORKDIR ${WORK_DIR}
 
-ENTRYPOINT [ "/usr/bin/mvn", "azure-functions:run" ]
+ENTRYPOINT [ "mvn", "azure-functions:run" ]

--- a/extension/WebJobs.Extensions.RabbitMQ.LangEndToEndTests/FunctionApps/java/Dockerfile
+++ b/extension/WebJobs.Extensions.RabbitMQ.LangEndToEndTests/FunctionApps/java/Dockerfile
@@ -25,6 +25,12 @@ COPY --from=dotnet /usr/share/dotnet /usr/share/dotnet
 RUN ln -sf /usr/share/dotnet/dotnet /usr/local/bin/dotnet
 ENV DOTNET_ROOT=/usr/share/dotnet
 
+# The dev container installs Maven via SDKMAN, which only wires it onto PATH in an
+# interactive shell. Symlink the mvn binary onto the system PATH for the build
+# (Java is located via JAVA_HOME, which the base image already sets).
+RUN ln -sf "$(ls -d /usr/local/sdkman/candidates/maven/*/bin/mvn | grep -v /current/ | head -1)" /usr/local/bin/mvn \
+    && mvn -version
+
 # Install Azure Functions Core Tools via npm (uses .NET 8)
 RUN npm install -g azure-functions-core-tools@4 --unsafe-perm true
 

--- a/extension/WebJobs.Extensions.RabbitMQ.LangEndToEndTests/FunctionApps/python/Dockerfile
+++ b/extension/WebJobs.Extensions.RabbitMQ.LangEndToEndTests/FunctionApps/python/Dockerfile
@@ -1,12 +1,26 @@
-# Use .NET 8 SDK as base with Node.js for npm install of Core Tools
-FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim
+# The isolated CI agents cannot reach Docker Hub, NodeSource, or the Debian apt
+# repos, so Node.js and the .NET SDK are copied in from MCR images instead of
+# being installed with apt/NodeSource.
 
-# Install Node.js and Python 3.11
-RUN apt-get update && \
-    apt-get install -y curl gnupg python3.11 python3-pip python3-venv && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs && \
-    rm -rf /var/lib/apt/lists/*
+# Node.js (for the Core Tools npm install) from the MCR Docker Hub mirror
+FROM mcr.microsoft.com/mirror/docker/library/node:20-bookworm-slim AS node
+
+# .NET 8 SDK to build the extension bundle
+FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS dotnet
+
+# Python 3.11 base already bundles Python + pip (from the MCR Docker Hub mirror)
+FROM mcr.microsoft.com/mirror/docker/library/python:3.11-bookworm
+
+# Bring in Node.js from the mirror stage
+COPY --from=node /usr/local/bin/node /usr/local/bin/node
+COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+
+# Bring in the .NET 8 SDK
+COPY --from=dotnet /usr/share/dotnet /usr/share/dotnet
+RUN ln -sf /usr/share/dotnet/dotnet /usr/local/bin/dotnet
+ENV DOTNET_ROOT=/usr/share/dotnet
 
 # Install Azure Functions Core Tools via npm (uses .NET 8)
 RUN npm install -g azure-functions-core-tools@4 --unsafe-perm true

--- a/extension/WebJobs.Extensions.RabbitMQ.LangEndToEndTests/RabbitMQE2EFixture.cs
+++ b/extension/WebJobs.Extensions.RabbitMQ.LangEndToEndTests/RabbitMQE2EFixture.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.ComponentModel;
 using System.Diagnostics;
 using Azure.Storage.Queues;
 using RabbitMQ.Client;
@@ -72,7 +73,7 @@ public class RabbitMQE2EFixture : IAsyncLifetime
         while (!string.IsNullOrEmpty(dir))
         {
             var gitPath = Path.Combine(dir, ".git");
-            if (Directory.Exists(gitPath))
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 // Found repo root, look for docker-compose.yml in LangEndToEndTests
                 var dockerComposePath = Path.Combine(dir, "extension", "WebJobs.Extensions.RabbitMQ.LangEndToEndTests", "docker-compose.yml");
@@ -110,20 +111,12 @@ public class RabbitMQE2EFixture : IAsyncLifetime
     /// <summary>
     /// Gets the docker compose command. Tries "docker compose" (V2) first, then falls back to "docker-compose" (V1).
     /// </summary>
-    private static (string FileName, string CommandPrefix) GetDockerComposeCommand()
+    private static (string FileName, IReadOnlyList<string> CommandPrefix) GetDockerComposeCommand()
     {
         // Try docker compose V2 first (docker compose as a subcommand)
         try
         {
-            var psi = new ProcessStartInfo
-            {
-                FileName = "docker",
-                Arguments = "compose version",
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
+            var psi = CreateProcessStartInfo("docker", ["compose", "version"]);
 
             using var process = Process.Start(psi);
             if (process is not null)
@@ -132,47 +125,41 @@ public class RabbitMQE2EFixture : IAsyncLifetime
                 if (process.ExitCode == 0)
                 {
                     Console.WriteLine("Using docker compose V2");
-                    return ("docker", "compose");
+                    return ("docker", ["compose"]);
                 }
             }
         }
-        catch
+        catch (Win32Exception)
         {
             // Ignore and try V1
         }
 
         // Fall back to docker-compose V1
         Console.WriteLine("Using docker-compose V1");
-        return ("docker-compose", "");
+        return ("docker-compose", []);
     }
 
     private async Task StartDockerComposeAsync()
     {
         var (fileName, commandPrefix) = GetDockerComposeCommand();
-        var arguments = string.IsNullOrEmpty(commandPrefix) 
-            ? "up -d --build" 
-            : $"{commandPrefix} up -d --build";
+        var arguments = new List<string>(commandPrefix);
+        AddComposeFiles(arguments);
+        arguments.Add("up");
+        arguments.Add("-d");
+        arguments.Add("--build");
 
-        var psi = new ProcessStartInfo
-        {
-            FileName = fileName,
-            Arguments = arguments,
-            WorkingDirectory = _dockerComposeDirectory,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true
-        };
+        var psi = CreateProcessStartInfo(fileName, arguments, _dockerComposeDirectory);
 
-        Console.WriteLine($"Running: {fileName} {arguments} in {_dockerComposeDirectory}");
+        Console.WriteLine($"Running: {fileName} {string.Join(' ', arguments)} in {_dockerComposeDirectory}");
 
         _dockerComposeProcess = Process.Start(psi)
             ?? throw new InvalidOperationException("Failed to start docker-compose");
 
-        var output = await _dockerComposeProcess.StandardOutput.ReadToEndAsync();
-        var error = await _dockerComposeProcess.StandardError.ReadToEndAsync();
-
+        var outputTask = _dockerComposeProcess.StandardOutput.ReadToEndAsync();
+        var errorTask = _dockerComposeProcess.StandardError.ReadToEndAsync();
         await _dockerComposeProcess.WaitForExitAsync();
+        var output = await outputTask;
+        var error = await errorTask;
 
         if (_dockerComposeProcess.ExitCode != 0)
         {
@@ -185,26 +172,69 @@ public class RabbitMQE2EFixture : IAsyncLifetime
     private async Task StopDockerComposeAsync()
     {
         var (fileName, commandPrefix) = GetDockerComposeCommand();
-        var arguments = string.IsNullOrEmpty(commandPrefix) 
-            ? "down --remove-orphans" 
-            : $"{commandPrefix} down --remove-orphans";
+        var arguments = new List<string>(commandPrefix);
+        AddComposeFiles(arguments);
+        arguments.Add("down");
+        arguments.Add("--remove-orphans");
 
-        var psi = new ProcessStartInfo
+        var psi = CreateProcessStartInfo(fileName, arguments, _dockerComposeDirectory);
+
+        using var process = Process.Start(psi);
+        if (process is not null)
+        {
+            var outputTask = process.StandardOutput.ReadToEndAsync();
+            var errorTask = process.StandardError.ReadToEndAsync();
+            await process.WaitForExitAsync();
+            await Task.WhenAll(outputTask, errorTask);
+        }
+    }
+
+    private void AddComposeFiles(List<string> arguments)
+    {
+        var cfsOverride = Environment.GetEnvironmentVariable("CFS_DOCKER_COMPOSE_OVERRIDE");
+        if (string.IsNullOrWhiteSpace(cfsOverride))
+        {
+            return;
+        }
+
+        if (!File.Exists(cfsOverride))
+        {
+            throw new FileNotFoundException("The CFS Docker Compose override file does not exist.", cfsOverride);
+        }
+
+        arguments.Add("--file");
+        arguments.Add(Path.Combine(_dockerComposeDirectory, "docker-compose.yml"));
+
+        var localOverride = Path.Combine(_dockerComposeDirectory, "docker-compose.override.yml");
+        if (File.Exists(localOverride))
+        {
+            arguments.Add("--file");
+            arguments.Add(localOverride);
+        }
+
+        arguments.Add("--file");
+        arguments.Add(cfsOverride);
+    }
+
+    private static ProcessStartInfo CreateProcessStartInfo(
+        string fileName, IEnumerable<string> arguments, string? workingDirectory = null)
+    {
+        var processStartInfo = new ProcessStartInfo
         {
             FileName = fileName,
-            Arguments = arguments,
-            WorkingDirectory = _dockerComposeDirectory,
+            WorkingDirectory = workingDirectory ?? string.Empty,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
             CreateNoWindow = true
         };
 
-        using var process = Process.Start(psi);
-        if (process is not null)
+        foreach (var argument in arguments)
         {
-            await process.WaitForExitAsync();
+            processStartInfo.ArgumentList.Add(argument);
         }
+
+        return processStartInfo;
     }
 
     private async Task WaitForRabbitMQAsync()


### PR DESCRIPTION
## Summary

- route repository-owned NuGet restores through `azfunc/public/upstream-public` with a root source-mapped `NuGet.config`
- authenticate and restore explicitly in each .NET Azure Pipelines job, then disable implicit downstream restores
- preserve the checked-in Java/Python function-app manifests and Dockerfiles while generating temporary CI-only Dockerfiles and authenticated npm, NuGet, and PyPI configuration
- pass package credentials only as BuildKit secrets and remove package configuration from final E2E images
- use safe process argument arrays and concurrent stream reads for Docker Compose paths, including paths containing spaces

## Dependency surfaces

- **NuGet:** extension solution, unit tests, C# E2E tests, language E2E test harness, and function-app extension restores
- **npm:** global Azure Functions Core Tools install in both language E2E images; `@types` production scope included
- **Python:** Python function-app requirements and pip upgrade in the E2E image
- **Preserved:** customer-facing function-app Dockerfiles, requirements, Maven POMs, and extension projects remain unchanged

## Validation

- restored the complete NuGet graph from empty isolated package/HTTP caches using only `pkgs.dev.azure.com`; zero NuGet.org requests
- installed Azure Functions Core Tools from an empty isolated npm cache; zero npmjs requests; `func --version` returned `4.12.1`
- installed Python requirements in a new isolated virtual environment/cache; zero PyPI/pythonhosted requests; `pip check` and `import azure.functions` passed
- built both generated language E2E images with `--no-cache`, then ran all 3 Docker Compose infrastructure tests successfully
- built the extension solution and language E2E test project; all 54 extension unit tests passed
- built the Java library in an isolated copied tree
- produced and inspected the NuGet, symbols, runtime jar, sources jar, and javadoc jar artifacts
- scanned final Docker image history, environment, and filesystems: zero credentials, package configs, lockfiles, or workspace `node_modules`
- verified the original local Docker context excludes the new root `NuGet.config`, preserving its local package source behavior

## Notes

Maven dependency routing is unchanged because this onboarding scope and supplied CFS endpoints cover npm, NuGet, and Python. Existing Maven Central traffic remains visible in the E2E build evidence.