### PR TITLE
Build: route Maven restores through CFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Shell scripts must keep LF terminators so they stay executable on Linux agents.
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Written by eng/scripts/Install-MavenCredentialProvider.ps1 and its Bash counterpart.
+.mvn/

--- a/README.md
+++ b/README.md
@@ -54,6 +54,89 @@ The following Java annotations are common to both RabbitMQ trigger and output bi
 
 Please refer to the Microsoft Docs page on [RabbitMQ bindings for Azure Functions overview](https://learn.microsoft.com/azure/azure-functions/functions-bindings-rabbitmq). It contains install instructions for all the supported programming languages, information on setting up and configuring the function app, and the  list of Azure App Service plans that support hosting of the function apps with RabbitMQ bindings.
 
+## Package feed
+
+All Maven packages and plugins are restored from the `upstream-public` Azure Artifacts feed
+(`https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1`), which is configured
+as the `central` repository in `java-library/pom.xml` and in the Java end-to-end test app. NuGet
+restores already go through the same feed via [`NuGet.config`](NuGet.config).
+
+The repository root also has a [`settings.xml`](settings.xml) that mirrors every remote repository
+(`external:*`) to the same feed. It exists because a `pom.xml` cannot cover everything:
+
+- Maven resolves build extensions and plugin prefixes *before* a pom's `<repositories>` are honored,
+  so those requests would otherwise go straight to Maven Central.
+- `MavenAuthenticate@0` and the credential provider key credentials off the Azure Artifacts *feed
+  name* (`upstream-public`), while the pom repository id must be `central` in order to override the
+  id Maven inherits from the Super POM. The mirror id bridges the two.
+- `java-library/pom.xml` inherits `java-8-parent`, which contributes a Sonatype snapshot plugin
+  repository this repository does not own. Only the mirror can keep that traffic on the feed.
+
+CI installs this file to `~/.m2/settings.xml`, and the end-to-end test image installs the same file
+so container builds resolve through the feed too. Locally you only need it when pulling a package or
+version the feed has not cached yet, in which case pass it explicitly with `mvn -s settings.xml`.
+
+### Anonymous restore (default)
+
+The feed allows anonymous reads, so no credentials are required to build once a package version has
+been saved to the feed. External contributors and fresh clones need no setup. `mvn` just works.
+Never commit credentials or a `<server>` entry to `settings.xml` in this repository because doing so
+would force authentication on everyone.
+
+### Authenticating (Microsoft developers only)
+
+Authentication is only needed to *ingest* a package version that the feed has not cached yet. The
+first restore of any new or upgraded dependency will fail anonymously with:
+
+> No local versions of package '...'; please provide authentication to access versions from upstream
+> that have not yet been saved to your feed.
+
+When that happens, a Microsoft developer with access to the `azfunc/public` project must run the
+restore once with credentials, which pulls the version from upstream and saves it to the feed. Every
+subsequent anonymous restore then succeeds.
+
+The recommended way to authenticate is the `artifacts-maven-credprovider`, which acquires a token via
+Entra ID so you do not have to manage a PAT.
+
+Run the helper script for your shell from the root of your clone. It installs the credential provider
+into your local Maven repository if it is missing, then writes `.mvn/extensions.xml`. Both scripts
+are idempotent, so re-running them is safe:
+
+```powershell
+./eng/scripts/Install-MavenCredentialProvider.ps1
+```
+
+```bash
+./eng/scripts/install-maven-credprovider.sh
+```
+
+Pass `-Version` / `--version` to install a different release, and `-Force` / `--force` to reinstall or
+to overwrite an `.mvn/extensions.xml` the script does not manage.
+
+`.mvn/` is deliberately listed in `.gitignore`. Do not commit it. The extension exits when it detects
+a build context, and committing it would break anonymous restores for everyone else.
+
+If you would rather not use the credential provider, you can instead add a `<server>` entry to your
+user-level `~/.m2/settings.xml` (never to a file inside this repository), using an Azure DevOps
+personal access token with Packaging read and write scope:
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <!-- Must match the <id> of the repository declared in the pom.xml files. -->
+      <id>central</id>
+      <username>azfunc</username>
+      <password>[PERSONAL_ACCESS_TOKEN]</password>
+    </server>
+  </servers>
+</settings>
+```
+
+CI covers this automatically. The `MavenAuthenticate@0` task in the build templates authenticates the
+feed, so merged changes to dependency versions are ingested by the pipeline. The credential provider
+is not used in pipelines.
+
 ## Contributing
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.

--- a/README.md
+++ b/README.md
@@ -72,9 +72,11 @@ The repository root also has a [`settings.xml`](settings.xml) that mirrors every
 - `java-library/pom.xml` inherits `java-8-parent`, which contributes a Sonatype snapshot plugin
   repository this repository does not own. Only the mirror can keep that traffic on the feed.
 
-CI installs this file to `~/.m2/settings.xml`, and the end-to-end test image installs the same file
-so container builds resolve through the feed too. Locally you only need it when pulling a package or
+CI installs this file to `~/.m2/settings.xml`. Locally you only need it when pulling a package or
 version the feed has not cached yet, in which case pass it explicitly with `mvn -s settings.xml`.
+
+The end-to-end test image does not need it. Its `pom.xml` declares the feed as `central`, which
+covers dependency and plugin resolution inside the container.
 
 ### Anonymous restore (default)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -210,6 +210,19 @@ jobs:
             vmImage: ubuntu-latest
 
         steps:
+          # Maven resolves plugins and extensions before a pom's repositories are honored. Install
+          # the mirror before MavenAuthenticate@0, which adds credentials to the same settings file.
+          - pwsh: |
+              $m2 = Join-Path $HOME '.m2'
+              New-Item -ItemType Directory -Path $m2 -Force | Out-Null
+              Copy-Item '$(Build.SourcesDirectory)/settings.xml' (Join-Path $m2 'settings.xml') -Force
+            displayName: Install Maven settings.xml
+
+          - task: MavenAuthenticate@0
+            displayName: Authenticate Maven to CFS
+            inputs:
+              artifactsFeeds: upstream-public
+
           - ${{ if eq(variables.isReleaseBuild, 'True') }}:
             - powershell: | # Allow tags matching v1.2.3 and v1.2.3-xyz1
                 $found = '$(Build.SourceBranchName)' | Select-String -Pattern '^v((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-\w+)?)$'

--- a/eng/ci/templates/official/build-extension.yml
+++ b/eng/ci/templates/official/build-extension.yml
@@ -71,7 +71,11 @@ jobs:
         displayName: Test extension
         inputs:
           command: test
-          workingDirectory: extension
+          # Unit tests only, matching the public template. The container based end-to-end suites
+          # need a Docker daemon that can run Linux images, which this Windows pool does not have.
+          # They run in the Linux public pipeline, which sets RABBITMQ_TEST_IMAGE to an MCR mirror.
+          projects: |
+            extension/WebJobs.Extensions.RabbitMQ.Tests/WebJobs.Extensions.RabbitMQ.Tests.csproj
           arguments: --no-restore --configuration Debug
 
       - template: ci/sign-files.yml@eng

--- a/eng/ci/templates/official/build-java-library.yml
+++ b/eng/ci/templates/official/build-java-library.yml
@@ -18,6 +18,19 @@ jobs:
           targetPath: $(Build.ArtifactStagingDirectory)
           artifactName: drop-java-library
     steps:
+      # Maven resolves plugins and extensions before a pom's repositories are honored. Install the
+      # mirror before MavenAuthenticate@0, which adds credentials to the same settings file.
+      - pwsh: |
+          $m2 = Join-Path $HOME '.m2'
+          New-Item -ItemType Directory -Path $m2 -Force | Out-Null
+          Copy-Item '$(Build.SourcesDirectory)/settings.xml' (Join-Path $m2 'settings.xml') -Force
+        displayName: Install Maven settings.xml
+
+      - task: MavenAuthenticate@0
+        displayName: Authenticate Maven to CFS
+        inputs:
+          artifactsFeeds: upstream-public
+
       - ${{ if eq(variables.isTaggedBuild, 'True') }}:
           - powershell: | # Allow tags matching v1.2.3 and v1.2.3-xyz1
               $found = '$(Build.SourceBranchName)' | Select-String -Pattern '^v((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-\w+)?)$'

--- a/eng/ci/templates/public/build-java-library.yml
+++ b/eng/ci/templates/public/build-java-library.yml
@@ -9,6 +9,19 @@ jobs:
     variables:
       version: ${{ parameters.version }}
     steps:
+      # Maven resolves plugins and extensions before a pom's repositories are honored. Install the
+      # mirror before MavenAuthenticate@0, which adds credentials to the same settings file.
+      - pwsh: |
+          $m2 = Join-Path $HOME '.m2'
+          New-Item -ItemType Directory -Path $m2 -Force | Out-Null
+          Copy-Item '$(Build.SourcesDirectory)/settings.xml' (Join-Path $m2 'settings.xml') -Force
+        displayName: Install Maven settings.xml
+
+      - task: MavenAuthenticate@0
+        displayName: Authenticate Maven to CFS
+        inputs:
+          artifactsFeeds: upstream-public
+
       # A combination of --batch-mode and --define=org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
       # options prevents spurious logging about downloading of Maven packages.
       - task: Maven@3

--- a/eng/scripts/Install-MavenCredentialProvider.ps1
+++ b/eng/scripts/Install-MavenCredentialProvider.ps1
@@ -1,0 +1,156 @@
+#!/usr/bin/env pwsh
+
+<#
+.SYNOPSIS
+    Bootstraps the Azure Artifacts Maven credential provider for local development.
+
+.DESCRIPTION
+    Maven packages for this repository are restored from an Azure Artifacts feed. Reads are
+    anonymous, so this script is only needed by Microsoft developers who have to ingest a package
+    version that the feed has not cached yet.
+
+    The script:
+      1. Verifies the credential provider is present in the local Maven repository, and downloads it
+         from the public AzureArtifacts tools feed if it is not.
+      2. Writes '.mvn/extensions.xml' at the root of the repository so Maven loads the provider.
+
+    '.mvn/' is intentionally listed in .gitignore. The extension exits when it detects a build
+    context, and committing it would force an authenticated restore on anonymous consumers. Azure
+    Pipelines uses the MavenAuthenticate@0 task instead.
+
+.PARAMETER Version
+    Version of the credential provider to install. Defaults to the version pinned by this script.
+
+.PARAMETER LocalRepositoryPath
+    Path to the local Maven repository. Defaults to '~/.m2/repository'.
+
+.PARAMETER Force
+    Overwrite an existing '.mvn/extensions.xml' even if it declares extensions this script does not
+    manage, and re-download the credential provider even when it is already installed.
+
+.EXAMPLE
+    ./eng/scripts/Install-MavenCredentialProvider.ps1
+
+.LINK
+    https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/azure-artifacts/maven-credprovider
+#>
+
+[CmdletBinding()]
+param(
+    [string] $Version = '3.2.1',
+    [string] $LocalRepositoryPath,
+    [switch] $Force
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$groupId = 'com.microsoft.azure'
+$artifactId = 'artifacts-maven-credprovider'
+$bootstrapFeed = 'https://pkgs.dev.azure.com/artifacts-public/PublicTools/_packaging/AzureArtifacts/maven/v1'
+
+# Maven records the extension against this repository id. It must match the <id> of the repositories
+# declared in this repository's pom.xml files, otherwise resolution fails validation later.
+$repositoryId = 'central'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+
+if (-not (Get-Command mvn -ErrorAction SilentlyContinue)) {
+    throw "Maven ('mvn') was not found on PATH. Install Apache Maven 3.0 or above and try again."
+}
+
+if (-not $LocalRepositoryPath) {
+    $LocalRepositoryPath = Join-Path $HOME '.m2' 'repository'
+}
+
+$artifactDirectory = $LocalRepositoryPath
+foreach ($segment in ($groupId.Split('.') + @($artifactId, $Version))) {
+    $artifactDirectory = Join-Path $artifactDirectory $segment
+}
+
+$artifactPath = Join-Path $artifactDirectory "$artifactId-$Version.jar"
+
+if ((Test-Path $artifactPath) -and -not $Force) {
+    Write-Host "Credential provider $Version is already installed at '$artifactPath'."
+}
+else {
+    Write-Host "Installing credential provider $Version from the public tools feed..."
+
+    # The bootstrap must run outside of any Maven project so that this repository's own repository
+    # and extension configuration does not take part in resolving the extension itself.
+    $workingDirectory = Join-Path ([IO.Path]::GetTempPath()) ('credprovider-bootstrap-' + [Guid]::NewGuid().ToString('n'))
+    New-Item -ItemType Directory -Path $workingDirectory -Force | Out-Null
+
+    try {
+        Push-Location $workingDirectory
+        try {
+            $mvnArgs = @(
+                '--batch-mode'
+                'dependency:get'
+                "-Dartifact=${groupId}:${artifactId}:${Version}"
+                "-DremoteRepositories=${repositoryId}::::${bootstrapFeed}"
+            )
+
+            if ($PSBoundParameters.ContainsKey('LocalRepositoryPath')) {
+                $mvnArgs += "-Dmaven.repo.local=$LocalRepositoryPath"
+            }
+
+            & mvn @mvnArgs
+            if ($LASTEXITCODE -ne 0) {
+                throw "'mvn dependency:get' failed with exit code $LASTEXITCODE."
+            }
+        }
+        finally {
+            Pop-Location
+        }
+    }
+    finally {
+        Remove-Item $workingDirectory -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    if (-not (Test-Path $artifactPath)) {
+        throw "Bootstrap reported success but '$artifactPath' was not found. If a mirror is configured in your settings.xml, temporarily disable it and retry."
+    }
+
+    Write-Host "Installed credential provider to '$artifactPath'."
+}
+
+$extensionsDirectory = Join-Path $repoRoot '.mvn'
+$extensionsPath = Join-Path $extensionsDirectory 'extensions.xml'
+
+if ((Test-Path $extensionsPath) -and -not $Force) {
+    $existing = Get-Content $extensionsPath -Raw
+
+    if ($existing -notmatch [regex]::Escape($artifactId)) {
+        throw "'$extensionsPath' already exists and declares extensions this script does not manage. Review it manually, or re-run with -Force to overwrite it."
+    }
+
+    if ($existing -match "<version>\s*$([regex]::Escape($Version))\s*</version>") {
+        Write-Host "'$extensionsPath' is already configured for version $Version."
+        Write-Host 'Done.'
+        return
+    }
+}
+
+$extensionsContent = @"
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Generated by eng/scripts/Install-MavenCredentialProvider.ps1. Do not commit this file: it is
+  ignored by .gitignore because the extension exits inside build environments and would break
+  anonymous package restore for other consumers.
+-->
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.1.0 https://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>$groupId</groupId>
+    <artifactId>$artifactId</artifactId>
+    <version>$Version</version>
+  </extension>
+</extensions>
+"@
+
+New-Item -ItemType Directory -Path $extensionsDirectory -Force | Out-Null
+Set-Content -Path $extensionsPath -Value $extensionsContent -Encoding utf8
+
+Write-Host "Wrote '$extensionsPath' for version $Version."
+Write-Host 'Done.'

--- a/eng/scripts/install-maven-credprovider.sh
+++ b/eng/scripts/install-maven-credprovider.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#
+# Bootstraps the Azure Artifacts Maven credential provider for local development.
+#
+# Maven packages for this repository are restored from an Azure Artifacts feed. Reads are anonymous,
+# so this script is only needed by Microsoft developers who have to ingest a package version that
+# the feed has not cached yet.
+#
+# The script:
+#   1. Verifies the credential provider is present in the local Maven repository, and downloads it
+#      from the public AzureArtifacts tools feed if it is not.
+#   2. Writes '.mvn/extensions.xml' at the root of the repository so Maven loads the provider.
+#
+# '.mvn/' is intentionally listed in .gitignore. The extension exits when it detects a build context,
+# and committing it would force an authenticated restore on anonymous consumers. Azure Pipelines
+# uses the MavenAuthenticate@0 task instead.
+#
+# See https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/azure-artifacts/maven-credprovider
+
+set -euo pipefail
+
+GROUP_ID='com.microsoft.azure'
+ARTIFACT_ID='artifacts-maven-credprovider'
+BOOTSTRAP_FEED='https://pkgs.dev.azure.com/artifacts-public/PublicTools/_packaging/AzureArtifacts/maven/v1'
+
+# Maven records the extension against this repository id. It must match the <id> of the repositories
+# declared in this repository's pom.xml files, otherwise resolution fails validation later.
+REPOSITORY_ID='central'
+
+version='3.2.1'
+local_repository_path=''
+force=false
+
+usage() {
+    cat <<'EOF'
+Usage: install-maven-credprovider.sh [options]
+
+Options:
+  -v, --version <version>            Version of the credential provider to install.
+  -l, --local-repository <path>      Path to the local Maven repository. Defaults to ~/.m2/repository.
+  -f, --force                        Overwrite an unmanaged .mvn/extensions.xml and re-download the
+                                     credential provider even when it is already installed.
+  -h, --help                         Show this help text.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -v|--version)
+            [[ $# -ge 2 ]] || { echo "error: $1 requires a value" >&2; exit 1; }
+            version="$2"
+            shift 2
+            ;;
+        -l|--local-repository)
+            [[ $# -ge 2 ]] || { echo "error: $1 requires a value" >&2; exit 1; }
+            local_repository_path="$2"
+            shift 2
+            ;;
+        -f|--force)
+            force=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "error: unknown argument '$1'" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/../.." && pwd)"
+
+if ! command -v mvn >/dev/null 2>&1; then
+    echo "error: Maven ('mvn') was not found on PATH. Install Apache Maven 3.0 or above and try again." >&2
+    exit 1
+fi
+
+local_repository_specified=true
+if [[ -z "$local_repository_path" ]]; then
+    local_repository_specified=false
+    local_repository_path="$HOME/.m2/repository"
+fi
+
+group_path="${GROUP_ID//./\/}"
+artifact_path="$local_repository_path/$group_path/$ARTIFACT_ID/$version/$ARTIFACT_ID-$version.jar"
+
+if [[ -f "$artifact_path" && "$force" != true ]]; then
+    echo "Credential provider $version is already installed at '$artifact_path'."
+else
+    echo "Installing credential provider $version from the public tools feed..."
+
+    # The bootstrap must run outside of any Maven project so that this repository's own repository
+    # and extension configuration does not take part in resolving the extension itself.
+    working_directory="$(mktemp -d)"
+    cleanup() { rm -rf "$working_directory"; }
+    trap cleanup EXIT
+
+    mvn_args=(
+        --batch-mode
+        dependency:get
+        "-Dartifact=${GROUP_ID}:${ARTIFACT_ID}:${version}"
+        "-DremoteRepositories=${REPOSITORY_ID}::::${BOOTSTRAP_FEED}"
+    )
+
+    if [[ "$local_repository_specified" == true ]]; then
+        mvn_args+=("-Dmaven.repo.local=$local_repository_path")
+    fi
+
+    (cd "$working_directory" && mvn "${mvn_args[@]}")
+
+    if [[ ! -f "$artifact_path" ]]; then
+        echo "error: bootstrap reported success but '$artifact_path' was not found." >&2
+        echo "If a mirror is configured in your settings.xml, temporarily disable it and retry." >&2
+        exit 1
+    fi
+
+    echo "Installed credential provider to '$artifact_path'."
+fi
+
+extensions_directory="$repo_root/.mvn"
+extensions_path="$extensions_directory/extensions.xml"
+
+if [[ -f "$extensions_path" && "$force" != true ]]; then
+    if ! grep -q "$ARTIFACT_ID" "$extensions_path"; then
+        echo "error: '$extensions_path' already exists and declares extensions this script does not manage." >&2
+        echo "Review it manually, or re-run with --force to overwrite it." >&2
+        exit 1
+    fi
+
+    if grep -qE "<version>[[:space:]]*${version//./\\.}[[:space:]]*</version>" "$extensions_path"; then
+        echo "'$extensions_path' is already configured for version $version."
+        echo 'Done.'
+        exit 0
+    fi
+fi
+
+mkdir -p "$extensions_directory"
+cat >"$extensions_path" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Generated by eng/scripts/install-maven-credprovider.sh. Do not commit this file: it is ignored by
+  .gitignore because the extension exits inside build environments and would break anonymous package
+  restore for other consumers.
+-->
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.1.0 https://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>$GROUP_ID</groupId>
+    <artifactId>$ARTIFACT_ID</artifactId>
+    <version>$version</version>
+  </extension>
+</extensions>
+EOF
+
+echo "Wrote '$extensions_path' for version $version."
+echo 'Done.'

--- a/extension/WebJobs.Extensions.RabbitMQ.LangEndToEndTests/FunctionApps/java/Dockerfile
+++ b/extension/WebJobs.Extensions.RabbitMQ.LangEndToEndTests/FunctionApps/java/Dockerfile
@@ -44,9 +44,6 @@ RUN mkdir /workspace
 COPY . /workspace
 WORKDIR ${WORK_DIR}
 
-# Route Maven restores in this image through the same CFS feed the pipelines use.
-RUN mkdir -p /root/.m2 && cp /workspace/settings.xml /root/.m2/settings.xml
-
 # Add local NuGet source for development packages
 RUN dotnet nuget add source /workspace/temp --name Local && dotnet nuget list source
 

--- a/extension/WebJobs.Extensions.RabbitMQ.LangEndToEndTests/FunctionApps/java/Dockerfile
+++ b/extension/WebJobs.Extensions.RabbitMQ.LangEndToEndTests/FunctionApps/java/Dockerfile
@@ -1,7 +1,7 @@
 # The isolated CI agents cannot reach Docker Hub, NodeSource, Adoptium, or the
 # Debian apt repos. The Microsoft Java dev container provides the Microsoft Build
 # of OpenJDK 21 on Debian bookworm; use it as the base, copy the .NET SDK and
-# Node.js from MCR images, and install Maven from Maven Central.
+# Node.js from MCR images, and install Maven from the CFS feed.
 FROM mcr.microsoft.com/mirror/docker/library/node:20-bookworm-slim AS node
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS dotnet
@@ -26,9 +26,9 @@ RUN ln -sf /usr/share/dotnet/dotnet /usr/local/bin/dotnet
 ENV DOTNET_ROOT=/usr/share/dotnet
 
 # The dev container ships the Microsoft Build of OpenJDK but not Maven. Install
-# Maven from Maven Central (which the build needs anyway) and put it on PATH.
-# Java is located via JAVA_HOME, which the base image already sets.
-RUN curl -fsSL https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.tar.gz \
+# Maven from the CFS feed and put it on PATH. Java is located via JAVA_HOME,
+# which the base image already sets.
+RUN curl -fsSL https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.tar.gz \
     | tar -xz -C /opt \
     && ln -sf /opt/apache-maven-3.9.9/bin/mvn /usr/local/bin/mvn \
     && mvn -version
@@ -43,6 +43,9 @@ ARG TARGET_DIR=${WORK_DIR}/target/azure-functions/RabbitMQE2E
 RUN mkdir /workspace
 COPY . /workspace
 WORKDIR ${WORK_DIR}
+
+# Route Maven restores in this image through the same CFS feed the pipelines use.
+RUN mkdir -p /root/.m2 && cp /workspace/settings.xml /root/.m2/settings.xml
 
 # Add local NuGet source for development packages
 RUN dotnet nuget add source /workspace/temp --name Local && dotnet nuget list source

--- a/extension/WebJobs.Extensions.RabbitMQ.LangEndToEndTests/FunctionApps/java/pom.xml
+++ b/extension/WebJobs.Extensions.RabbitMQ.LangEndToEndTests/FunctionApps/java/pom.xml
@@ -18,6 +18,33 @@
         <functionAppName>RabbitMQE2E</functionAppName>
     </properties>
 
+    <!-- Package sources must be routed through an Azure Artifacts feed (CFS). -->
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.functions</groupId>

--- a/java-library/pom.xml
+++ b/java-library/pom.xml
@@ -63,11 +63,22 @@
     </snapshotRepository>
   </distributionManagement>
 
+  <!-- Package sources must be routed through an Azure Artifacts feed (CFS). -->
   <repositories>
+    <repository>
+      <id>central</id>
+      <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
     <repository>
       <id>maven.snapshots</id>
       <name>Maven Central Snapshot Repository</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
       <releases>
         <enabled>false</enabled>
       </releases>
@@ -76,6 +87,30 @@
       </snapshots>
     </repository>
   </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>central</id>
+      <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </pluginRepository>
+    <!-- Override the snapshot plugin repository inherited from java-8-parent. -->
+    <pluginRepository>
+      <id>sonatype-nexus-snapshots</id>
+      <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
 
   <dependencies>
     <dependency>

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Maven settings for Central Feed Service (CFS).
+
+  Each pom.xml overrides the `central` repository so packages are served by the Azure Artifacts
+  feed below. The mirror covers what a pom cannot: plugins and extensions resolved before pom
+  repositories are honored, and repositories inherited from parent poms this repository does not
+  own. Its id matches the feed name used by MavenAuthenticate@0.
+
+  `external:*` is used instead of `central` so a repository stays on the feed no matter which id
+  its pom gives it.
+
+  CI installs this file to ~/.m2/settings.xml. For a local authenticated restore, install the
+  credential provider and pass this file when needed:
+
+      mvn -s settings.xml <goals>
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>upstream-public</id>
+      <name>Azure Functions public upstream feed</name>
+      <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+      <mirrorOf>external:*</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>


### PR DESCRIPTION
## Problem

The Build Java Library job is the only remaining source of non-CFS package traffic in this repo. 1ES network isolation on the latest `dev` builds records:

| Domain | linux.public | windows.public | official |
|---|---|---|---|
| `repo.maven.apache.org` | 14 | 10 | 16 |
| `repository.sonatype.org` | 20 | 1 | 1 |
| `oss.sonatype.org` | 5 | 4 | 4 |

That leaves CFSClean non-compliant on all three pipelines, and CFSClean2 non-compliant on windows.public and official. The other jobs, BuildExtension and Run E2E Tests with Docker, are already compliant thanks to #266.

There are three causes:

- `java-library/pom.xml` had no `central` override, so Maven Central stayed live from the Super POM.
- It declared a download repository under the id `maven.snapshots` pointing at Sonatype.
- It inherits `java-8-parent`, which contributes a `sonatype-nexus-snapshots` plugin repository.

On top of that, the CI templates called `Maven@3` with no settings file and no `MavenAuthenticate@0`.

## Change

- New root `settings.xml` mirroring `external:*` to `upstream-public`. `external:*` rather than `central` so a repository stays on the feed regardless of the id its pom gives it, which is what catches `maven.snapshots` and the inherited Sonatype repository.
- `java-library/pom.xml` points `central`, `maven.snapshots` and `sonatype-nexus-snapshots` at the feed. `distributionManagement` is untouched because that is the publishing target, not a restore source.
- The E2E function app pom gets `central` repositories and plugin repositories.
- Both `build-java-library.yml` templates install the settings file and run `MavenAuthenticate@0` before any Maven task. `azure-pipelines.yml` gets the same treatment.
- The E2E image acquires the Maven distribution from the feed instead of `repo1.maven.org`, which removes the last `repo1.maven.org` reference in the repo.
- Credential provider helper scripts, byte-identical to the ones already in the Java worker, library and additions repos.
- README section documenting the feed, plus `.mvn/` in `.gitignore` and `*.sh text eol=lf`.

## Also fixes the official pipeline

`rabbitmq-extension.official` has failed every run since at least 12 July, which is unrelated to CFS but small enough to fold in here.

Its `stage1` runs on `1es-windows-2022`, and the Test extension step had no `projects` filter, so `dotnet test` also picked up `WebJobs.Extensions.RabbitMQ.EndToEndTests`. Those tests start a RabbitMQ container through Testcontainers and fail with `No such image: rabbitmq:3-management-alpine`, because the Windows pool cannot pull it.

Those suites already have a home. `official-build.yml` defines an `e2eTestLinux` stage on `1es-ubuntu-22.04` that runs `run-e2e-tests.yml`, which sets `RABBITMQ_TEST_IMAGE` to the MCR mirror. That stage has `dependsOn: stage1`, so the Windows failure was also blocking the Linux stage from ever running.

The step is now restricted to the unit test project, matching what the public template already does. Happy to split this into its own PR if you would rather keep this one focused.

## Results

Both public pipelines were run against this PR. Every job reports all four policies compliant, with no flagged domains anywhere in either build.

| Pipeline | Build | Result |
|---|---|---|
| rabbitmq-extension-linux.public | 297937 | succeeded |
| rabbitmq-extension-windows.public | 297940 | succeeded |

Build Java Library went from CFSClean non-compliant with 10 to 16 violations down to compliant, and CFSClean2 from 5 violations down to compliant.

Locally, against empty local repositories:

| Check | Result |
|---|---|
| Effective POM download repos | all CFS, only `distributionManagement` left on Sonatype |
| Java library, empty cache, anonymous | BUILD SUCCESS, 646 artifacts, all CFS |
| E2E app, empty cache, anonymous | BUILD SUCCESS, 1121 artifacts, all CFS |
| Non-CFS downloads in any run | none |

These versions were ingested into `upstream-public` so the anonymous path works: `apache-maven` 3.9.9, `easymock` 4.3, `azure-functions-java-library` 3.2.3, `azure-functions-java-library-rabbitmq` 2.1.0, and the `azure-functions-maven-plugin` tree.

The official pipeline change cannot be exercised before merge. `code-mirror.yml` only mirrors `dev` to the internal repo, so this branch never reaches the pipeline that consumes `eng/ci/templates/official/`. The public pipelines do not reference that template, so it cannot affect the runs above.

## Notes

An earlier revision also installed `settings.xml` into the E2E image. That broke the image build because the file was not visible in the build context on the agent, and it was not needed, since that job is already compliant and the function app pom now declares the feed as `central`. It was dropped in b3ecc2a.

`azure-pipelines.yml` has no live pipeline definition pointing at it. I updated it for consistency, but it looks like dead code worth removing separately.
